### PR TITLE
adds comparison function objects and tests

### DIFF
--- a/cmake/basic_project-add-targets-impl.cmake
+++ b/cmake/basic_project-add-targets-impl.cmake
@@ -208,10 +208,12 @@ function(add_impl)
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
          -Weverything
          -Wno-unused-command-line-argument
-         -Wno-missing-prototypes
          -Wno-c++98-compat
          -Wno-c++98-compat-pedantic
-         -Wno-padded>)
+         -Wno-missing-prototypes
+         -Wno-missing-variable-declarations
+         -Wno-padded
+         -Wno-redundant-parens>)
    # Warnings as errors
    target_compile_options("${add_target_args_TARGET}" PRIVATE
       $<$<CXX_COMPILER_ID:MSVC>:

--- a/config/conan/profiles/clang-concepts
+++ b/config/conan/profiles/clang-concepts
@@ -1,0 +1,16 @@
+[settings]
+os=Linux
+os_build=Linux
+arch=x86_64
+arch_build=x86_64
+compiler=clang
+compiler.version=6.0
+compiler.libcxx=libstdc++11
+build_type=Release
+[options]
+[build_requires]
+[env]
+CC=/opt/clang-concepts/bin/clang
+CXX=/opt/clang-concepts/bin/clang++
+LDFLAGS=-std=c++2a -Xclang -fconcepts-ts
+CONAN_CMAKE_GENERATOR=Ninja

--- a/include/cjdb/detail/define.hpp
+++ b/include/cjdb/detail/define.hpp
@@ -38,23 +38,4 @@
 
 #define CJDB_ASSERT(...) CJDB_EXPECTS(__VA_ARGS__)
 
-namespace cjdb::detail_audit_mode {
-   #ifdef CJDB_AUDIT_CONTRACTS
-      inline constexpr auto audit_mode = true;
-   #else
-      inline constexpr auto audit_mode = false;
-   #endif // CJDB_AUDIT_CONTRACTS
-} // namespace cjdb::detail_audit_mode
-
-#define CJDB_EXPECTS_AUDIT(...) { \
-   if (cjdb::detail_audit_mode) { \
-      CJDB_EXPECTS(__VA_ARGS__);  \
-   }                              \
-}                                 \
-
-
-#define CJDB_ENSURES_AUDIT(...) CJDB_EXPECTS_AUDIT(__VA_ARGS__)
-
-#define CJDB_ASSERT_AUDIT(...) CJDB_EXPECTS_AUDIT(__VA_ARGS__)
-
 #endif // CJDB_DETAIL_DEFINE_HPP

--- a/include/cjdb/detail/functional/rangecmp/partial_equality.hpp
+++ b/include/cjdb/detail/functional/rangecmp/partial_equality.hpp
@@ -1,0 +1,60 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_EQUALITY_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_EQUALITY_HPP
+
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/detail/functional/rangecmp/partial_storage.hpp"
+#include "cjdb/functional/invoke.hpp"
+#include "cjdb/type_traits/expose_type.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+namespace cjdb::detail_partial_equality {
+   /// \brief Abstraction of `partial_equal_to` and `partial_not_equal_to`.
+   ///
+   /// `partial_equality` is a partial function: that is, we provide a one value now, and others
+   /// when the function is invoked. In keeping up with the 'you don't pay for what you don't use'
+   /// idiom employed by the C++ International Standard, `partial_equality` only stores a value if
+   /// it is constructed with an rvalue (this is to prevent issues with lifetime management).
+   ///
+   /// If `partial_equality` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   template<EqualityComparable T, class Op>
+   class partial_equality : private detail_partial_storage::partial_function_storage<T> {
+      using base = detail_partial_storage::partial_function_storage<T>;
+   public:
+      using base::base;
+      using base::value;
+
+      /// \breif Applies the equality operation.
+      /// \tparam U A type that is equality-comparable with T.
+      /// \param other The object to be compared with.
+      /// \returns `invoke(Op{}, value(), other)`
+      ///
+      template<EqualityComparableWith<T> U>
+      constexpr bool operator()(U&& other) const noexcept
+      {
+         return invoke(Op{}, value(), std::forward<U>(other));
+      }
+
+      using is_transparent = bool_constant<is_lvalue_reference_v<T>>;
+   };
+} // namespace cjdb::detail_partial_equality
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_EQUALITY_HPP

--- a/include/cjdb/detail/functional/rangecmp/partial_inequality.hpp
+++ b/include/cjdb/detail/functional/rangecmp/partial_inequality.hpp
@@ -1,0 +1,57 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_INEQUALITY_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_INEQUALITY_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+namespace cjdb::detail_partial_inequality {
+   /// \brief Abstraction of `partial_less` and friends.
+   ///
+   /// `partial_inequality` is a partial function: that is, we provide a one value now, and others
+   /// when the function is invoked. In keeping up with the 'you don't pay for what you don't use'
+   /// idiom employed by the C++ International Standard, `partial_inequality` only stores a value if
+   /// it is constructed with an rvalue (this is to prevent issues with lifetime management).
+   ///
+   /// If `partial_inequality` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   template<StrictTotallyOrdered T, class Op>
+   class partial_inequality : private detail_partial_storage::partial_function_storage<T> {
+      using base = detail_partial_storage::partial_function_storage<T>;
+   public:
+      using base::base;
+      using base::value;
+
+      /// \breif Applies the inequality operation.
+      /// \tparam U A type that is strict-totally-ordered with T.
+      /// \param other The object to be compared with.
+      /// \returns `invoke(Op{}, value(), other)`
+      ///
+      template<StrictTotallyOrderedWith<T> U>
+      constexpr bool operator()(U&& other) const noexcept
+      {
+         return invoke(Op{}, value(), std::forward<U>(other));
+      }
+
+      using is_transparent = bool_constant<is_lvalue_reference_v<T>>;
+   };
+} // namespace cjdb::detail_partial_inequality
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_INEQUALITY_HPP

--- a/include/cjdb/detail/functional/rangecmp/partial_storage.hpp
+++ b/include/cjdb/detail/functional/rangecmp/partial_storage.hpp
@@ -1,0 +1,81 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_STORAGE_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_STORAGE_HPP
+
+namespace cjdb::detail_partial_storage {
+   /// \brief Helper type to determine if a `partial_foo` stores a pointer-to-lvalue or an lvalue.
+   ///
+   /// If a user constructs a `partial_foo` with an lvalue, then the type of `partial_storage` is
+   /// pointer-to-`const T`. This makes `partial_foo<T&>` cheap to copy.
+   ///
+   /// If a user constructs a `partial_foo` with an rvalue, then the type of `partial_storage` is
+   /// `T`. This makes `partial_foo<T&&>` potentially expensive to copy, but ensures lifetime
+   /// safety.
+   ///
+   template<class T>
+   struct partial_storage {
+      using type = remove_reference_t<T> const*;
+   };
+
+   template<class T>
+   requires is_rvalue_reference_v<T>
+   struct partial_storage<T> {
+      using type = remove_reference_t<T>;
+   };
+
+   template<class T>
+   using partial_storage_t = _t<partial_storage<T>>;
+
+   template<class T>
+   class partial_function_storage {
+   public:
+      /// \brief Constructs `partial_function_storage`.
+      ///
+      /// \note This constructor participates in overload resolution if, and only if, T is an lvalue
+      ///       reference.
+      ///
+      constexpr explicit partial_function_storage(T const& value) noexcept
+      requires is_lvalue_reference_v<T>
+         : value_{std::addressof(value)}
+      {}
+
+      /// \brief Constructs `partial_function_storage`.
+      /// \note This constructor participates in overload resolution if, and only if, T is an rvalue
+      ///       reference.
+      ///
+      constexpr explicit partial_function_storage(remove_reference_t<T> value) noexcept
+      requires is_rvalue_reference_v<T>
+         : value_{std::move(value)}
+      {}
+
+      /// \brief Returns the value stored.
+      ///
+      constexpr auto const& value() const noexcept
+      {
+         if constexpr (is_lvalue_reference_v<T>) {
+            return *value_;
+         }
+         else {
+            return value_;
+         }
+      }
+   private:
+      partial_storage_t<T> value_;
+   };
+} // namespace cjdb::detail_partial_storage
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_STORAGE_HPP

--- a/include/cjdb/detail/undef.hpp
+++ b/include/cjdb/detail/undef.hpp
@@ -13,6 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#ifdef CJDB_DETAIL_DEFINE_HPP
+   #undef CJDB_DETAIL_DEFINE_HPP
+#else
+   #error "\"cjdb/detail/undef.hpp\" can only be included in a context where "
+          "\"cjdb/detail/define.hpp\" has already been included."
+#endif // CJDB_DETAIL_DEFINE_HPP
+
 #ifdef CJDB_NOEXCEPT_RETURN
    #undef CJDB_NOEXCEPT_RETURN
 #endif // CJDB_NOEXCEPT_RETURN
@@ -25,22 +32,10 @@
    #undef CJDB_EXPECTS
 #endif // CJDB_EXPECTS
 
-#ifdef CJDB_EXPECTS_AUDIT
-   #undef CJDB_EXPECTS_AUDIT
-#endif // CJDB_EXPECTS_AUDIT
-
 #ifdef CJDB_ENSURES
    #undef CJDB_ENSURES
 #endif // CJDB_ENSURES
 
-#ifdef CJDB_ENSURES_AUDIT
-   #undef CJDB_ENSURES_AUDIT
-#endif // CJDB_ENSURES_AUDIT
-
 #ifdef CJDB_ASSERT
    #undef CJDB_ASSERT
 #endif // CJDB_ASSERT
-
-#ifdef CJDB_ASSERT_AUDIT
-   #undef CJDB_ASSERT_AUDIT
-#endif // CJDB_ASSERT_AUDIT

--- a/include/cjdb/functional/rangecmp.hpp
+++ b/include/cjdb/functional/rangecmp.hpp
@@ -1,0 +1,30 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_DETAIL_FUNCTIONAL_RANGECMP_HPP
+#define CJDB_DETAIL_FUNCTIONAL_RANGECMP_HPP
+
+#include "cjdb/functional/rangecmp/equal_to.hpp"
+#include "cjdb/functional/rangecmp/not_equal_to.hpp"
+// #include "cjdb/functional/rangecmp/less.hpp"
+// #include "cjdb/functional/rangecmp/less_equal.hpp"
+// #include "cjdb/functional/rangecmp/greater.hpp"
+// #include "cjdb/functional/rangecmp/greater_equal.hpp"
+
+#include "cjdb/functional/rangecmp/partial_equal_to.hpp"
+#include "cjdb/functional/rangecmp/partial_not_equal_to.hpp"
+#include "cjdb/functional/rangecmp/partial_less.hpp"
+
+#endif // CJDB_DETAIL_FUNCTIONAL_RANGECMP_HPP

--- a/include/cjdb/functional/rangecmp/equal_to.hpp
+++ b/include/cjdb/functional/rangecmp/equal_to.hpp
@@ -1,0 +1,43 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_DETAIL_FUNCTIONAL_RANGECMP_EQUAL_TO_HPP
+#define CJDB_DETAIL_FUNCTIONAL_RANGECMP_EQUAL_TO_HPP
+
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+#include "cjdb/detail/define.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator==.
+   ///
+   struct equal_to {
+      /// \returns `true` if `t` is equal to `u`, `false` otherwise.
+      ///
+      template<class T, EqualityComparableWith<T> U>
+      constexpr bool operator()(T&& t, U&& u) const
+      CJDB_NOEXCEPT_RETURN(
+         static_cast<bool>(std::forward<T>(t) == std::forward<U>(u))
+      )
+
+      using is_transparent = true_type;
+   };
+} // namespace cjdb::ranges
+
+#include "cjdb/detail/undef.hpp"
+
+#endif // CJDB_DETAIL_FUNCTIONAL_RANGECMP_EQUAL_TO_HPP

--- a/include/cjdb/functional/rangecmp/greater.hpp
+++ b/include/cjdb/functional/rangecmp/greater.hpp
@@ -1,0 +1,44 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_DETAIL_FUNCTIONAL_RANGECMP_GREATER_HPP
+#define CJDB_DETAIL_FUNCTIONAL_RANGECMP_GREATER_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/functional/rangecmp/less.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+#include "cjdb/detail/define.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator>.
+   ///
+   struct greater {
+      /// \returns `true` if `u` is less than `t`, `false` otherwise.
+      ///
+      template<class T, StrictTotallyOrderedWith<T> U>
+      constexpr bool operator()(T&& t, U&& u) const
+      CJDB_NOEXCEPT_RETURN(
+         less{}(std::forward<U>(u), std::forward<T>(t))
+      )
+
+      using is_transparent = true_type;
+   };
+} // namespace cjdb::ranges
+
+#include "cjdb/detail/undef.hpp"
+
+#endif // CJDB_DETAIL_FUNCTIONAL_RANGECMP_GREATER_HPP

--- a/include/cjdb/functional/rangecmp/greater_equal.hpp
+++ b/include/cjdb/functional/rangecmp/greater_equal.hpp
@@ -1,0 +1,44 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_DETAIL_FUNCTIONAL_RANGECMP_GREATER_EQUAL_HPP
+#define CJDB_DETAIL_FUNCTIONAL_RANGECMP_GREATER_EQUAL_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/functional/rangecmp/less.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+#include "cjdb/detail/define.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator>=.
+   ///
+   struct greater_equal {
+      /// \returns `true` if `t` is not less than `u`, `false` otherwise.
+      ///
+      template<class T, StrictTotallyOrderedWith<T> U>
+      constexpr bool operator()(T&& t, U&& u) const
+      CJDB_NOEXCEPT_RETURN(
+         not less{}(std::forward<T>(t), std::forward<U>(u))
+      )
+
+      using is_transparent = true_type;
+   };
+} // namespace cjdb::ranges
+
+#include "cjdb/detail/undef.hpp"
+
+#endif // CJDB_DETAIL_FUNCTIONAL_RANGECMP_GREATER_EQUAL_HPP

--- a/include/cjdb/functional/rangecmp/less.hpp
+++ b/include/cjdb/functional/rangecmp/less.hpp
@@ -1,0 +1,43 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_DETAIL_FUNCTIONAL_RANGECMP_LESS_HPP
+#define CJDB_DETAIL_FUNCTIONAL_RANGECMP_LESS_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+#include "cjdb/detail/define.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator<.
+   ///
+   struct less {
+      /// \returns `true` if `t` is less than `u`, `false` otherwise.
+      ///
+      template<class T, StrictTotallyOrderedWith<T> U>
+      constexpr bool operator()(T&& t, U&& u) const
+      CJDB_NOEXCEPT_RETURN(
+         static_cast<bool>(std::forward<T>(t) < std::forward<U>(u))
+      )
+
+      using is_transparent = true_type;
+   };
+} // namespace cjdb::ranges
+
+#include "cjdb/detail/undef.hpp"
+
+#endif // CJDB_DETAIL_FUNCTIONAL_RANGECMP_LESS_HPP

--- a/include/cjdb/functional/rangecmp/less_equal.hpp
+++ b/include/cjdb/functional/rangecmp/less_equal.hpp
@@ -1,0 +1,44 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_DETAIL_FUNCTIONAL_RANGECMP_LESS_EQUAL_HPP
+#define CJDB_DETAIL_FUNCTIONAL_RANGECMP_LESS_EQUAL_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/functional/rangecmp/greater.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+#include "cjdb/detail/define.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator<=.
+   ///
+   struct less_equal {
+      /// \returns `true` if `t` is not greater than `u`, `false` otherwise.
+      ///
+      template<class T, StrictTotallyOrderedWith<T> U>
+      constexpr bool operator()(T&& t, U&& u) const
+      CJDB_NOEXCEPT_RETURN(
+         not greater{}(std::forward<T>(t), std::forward<U>(u))
+      )
+
+      using is_transparent = true_type;
+   };
+} // namespace cjdb::ranges
+
+#include "cjdb/detail/undef.hpp"
+
+#endif // CJDB_DETAIL_FUNCTIONAL_RANGECMP_LESS_EQUAL_HPP

--- a/include/cjdb/functional/rangecmp/not_equal_to.hpp
+++ b/include/cjdb/functional/rangecmp/not_equal_to.hpp
@@ -1,0 +1,44 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_DETAIL_FUNCTIONAL_RANGECMP_NOT_EQUAL_TO_HPP
+#define CJDB_DETAIL_FUNCTIONAL_RANGECMP_NOT_EQUAL_TO_HPP
+
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/functional/rangecmp/equal_to.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+#include "cjdb/detail/define.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator!=.
+   ///
+   struct not_equal_to {
+      /// \returns `true` if `t` is not equal to `u`, `false` otherwise.
+      ///
+      template<class T, EqualityComparableWith<T> U>
+      constexpr bool operator()(T&& t, U&& u) const
+      CJDB_NOEXCEPT_RETURN(
+         not equal_to{}(std::forward<T>(t), std::forward<U>(u))
+      )
+
+      using is_transparent = true_type;
+   };
+} // namespace cjdb::ranges
+
+#include "cjdb/detail/undef.hpp"
+
+#endif // CJDB_DETAIL_FUNCTIONAL_RANGECMP_NOT_EQUAL_TO_HPP

--- a/include/cjdb/functional/rangecmp/partial_equal_to.hpp
+++ b/include/cjdb/functional/rangecmp/partial_equal_to.hpp
@@ -1,0 +1,59 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_EQUAL_TO_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_EQUAL_TO_HPP
+
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/detail/functional/rangecmp/partial_equality.hpp"
+#include "cjdb/functional/rangecmp/equal_to.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator==.
+   ///
+   /// Unlike `equal_to`, `partial_equal_to` stores one object, and takes another as a unary
+   /// argument when it is called.
+   ///
+   /// `partial_equal_to` is a partial function: that is, we provide a one value now, and others
+   /// when the function is invoked. In keeping up with the 'you don't pay for what you don't use'
+   /// idiom employed by the C++ International Standard, `partial_equal_to` only stores a value if
+   /// it is constructed with an rvalue (this is to prevent issues with lifetime management).
+   ///
+   /// If `partial_equal_to` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   /// \note This is an extension.
+   ///
+   template<EqualityComparable T>
+   class partial_equal_to : private detail_partial_equality::partial_equality<T, ranges::equal_to> {
+   private:
+      using base = detail_partial_equality::partial_equality<T, ranges::equal_to>;
+   public:
+      using base::base;
+      using base::operator();
+      using base::value;
+      using typename base::is_transparent;
+   };
+
+   template<class T>
+   partial_equal_to(T&) -> partial_equal_to<T const&>;
+
+   template<class T>
+   partial_equal_to(T&&) -> partial_equal_to<remove_const_t<remove_reference_t<T>>&&>;
+} // namespace cjdb::ranges
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_EQUAL_TO_HPP

--- a/include/cjdb/functional/rangecmp/partial_greater.hpp
+++ b/include/cjdb/functional/rangecmp/partial_greater.hpp
@@ -1,0 +1,59 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_GREATER_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_GREATER_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/detail/functional/rangecmp/partial_inequality.hpp"
+#include "cjdb/functional/rangecmp/greater.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator>.
+   ///
+   /// Unlike `ranges::greater`, `partial_greater` stores one object, and takes another as a unary
+   /// argument when it is called.
+   ///
+   /// `partial_greater` is a partial function: that is, we provide a one value now, and others
+   /// when the function is invoked. In keeping up with the 'you don't pay for what you don't use'
+   /// idiom employed by the C++ International Standard, `partial_greater` only stores a value
+   /// if it is constructed with an rvalue (this is to prevent issues with lifetime management).
+   ///
+   /// If `partial_greater` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   /// \note This is an extension.
+   ///
+   template<StrictTotallyOrdered T>
+   class partial_greater
+   : private detail_partial_inequality::partial_inequality<T, ranges::greater> {
+   private:
+      using base = detail_partial_inequality::partial_inequality<T, ranges::greater>;
+   public:
+      using base::base;
+      using base::operator();
+      using base::value;
+      using typename base::is_transparent;
+   };
+
+   template<class T>
+   partial_greater(T&) -> partial_greater<T const&>;
+
+   template<class T>
+   partial_greater(T&&) -> partial_greater<remove_const_t<remove_reference_t<T>>&&>;
+} // namespace cjdb::ranges
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_GREATER_HPP

--- a/include/cjdb/functional/rangecmp/partial_greater_equal.hpp
+++ b/include/cjdb/functional/rangecmp/partial_greater_equal.hpp
@@ -1,0 +1,60 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_GREATER_EQUAL_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_GREATER_EQUAL_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/detail/functional/rangecmp/partial_inequality.hpp"
+#include "cjdb/functional/rangecmp/greater_equal.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator>=.
+   ///
+   /// Unlike `greater_equal`, `partial_greater_equal` stores one object, and takes another as a
+   /// unary argument when it is called.
+   ///
+   /// `partial_greater_equal` is a partial function: that is, we provide a one value now, and
+   /// others when the function is invoked. In keeping up with the 'you don't pay for what you don't
+   /// use' idiom employed by the C++ International Standard, `partial_greater_equal` only stores a
+   /// value if it is constructed with an rvalue (this is to prevent issues with lifetime
+   /// management).
+   ///
+   /// If `partial_greater_equal` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   /// \note This is an extension.
+   ///
+   template<StrictTotallyOrdered T>
+   class partial_greater_equal
+   : private detail_partial_inequality::partial_inequality<T, ranges::greater_equal> {
+   private:
+      using base = detail_partial_inequality::partial_inequality<T, ranges::greater_equal>;
+   public:
+      using base::base;
+      using base::operator();
+      using base::value;
+      using typename base::is_transparent;
+   };
+
+   template<class T>
+   partial_greater_equal(T&) -> partial_greater_equal<T const&>;
+
+   template<class T>
+   partial_greater_equal(T&&) -> partial_greater_equal<remove_const_t<remove_reference_t<T>>&&>;
+} // namespace cjdb::ranges
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_GREATER_EQUAL_HPP

--- a/include/cjdb/functional/rangecmp/partial_less.hpp
+++ b/include/cjdb/functional/rangecmp/partial_less.hpp
@@ -1,0 +1,58 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_LESS_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_LESS_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/detail/functional/rangecmp/partial_inequality.hpp"
+#include "cjdb/functional/rangecmp/less.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator<.
+   ///
+   /// Unlike `ranges::less`, `partial_less` stores one object, and takes another as a unary
+   /// argument when it is called.
+   ///
+   /// `partial_less` is a partial function: that is, we provide a one value now, and others
+   /// when the function is invoked. In keeping up with the 'you don't pay for what you don't use'
+   /// idiom employed by the C++ International Standard, `partial_less` only stores a value
+   /// if it is constructed with an rvalue (this is to prevent issues with lifetime management).
+   ///
+   /// If `partial_less` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   /// \note This is an extension.
+   ///
+   template<StrictTotallyOrdered T>
+   class partial_less : private detail_partial_inequality::partial_inequality<T, ranges::less> {
+   private:
+      using base = detail_partial_inequality::partial_inequality<T, ranges::less>;
+   public:
+      using base::base;
+      using base::operator();
+      using base::value;
+      using typename base::is_transparent;
+   };
+
+   template<class T>
+   partial_less(T&) -> partial_less<T const&>;
+
+   template<class T>
+   partial_less(T&&) -> partial_less<remove_const_t<remove_reference_t<T>>&&>;
+} // namespace cjdb::ranges
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_LESS_HPP

--- a/include/cjdb/functional/rangecmp/partial_less_equal.hpp
+++ b/include/cjdb/functional/rangecmp/partial_less_equal.hpp
@@ -1,0 +1,59 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_LESS_EQUAL_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_LESS_EQUAL_HPP
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/detail/functional/rangecmp/partial_inequality.hpp"
+#include "cjdb/functional/rangecmp/less_equal.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator<=.
+   ///
+   /// Unlike `less_equal`, `partial_less_equal` stores one object, and takes another as a unary
+   /// argument when it is called.
+   ///
+   /// `partial_less_equal` is a partial function: that is, we provide a one value now, and others
+   /// when the function is invoked. In keeping up with the 'you don't pay for what you don't use'
+   /// idiom employed by the C++ International Standard, `partial_less_equal` only stores a value
+   /// if it is constructed with an rvalue (this is to prevent issues with lifetime management).
+   ///
+   /// If `partial_less_equal` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   /// \note This is an extension.
+   ///
+   template<StrictTotallyOrdered T>
+   class partial_less_equal
+   : private detail_partial_inequality::partial_inequality<T, ranges::less_equal> {
+   private:
+      using base = detail_partial_inequality::partial_inequality<T, ranges::less_equal>;
+   public:
+      using base::base;
+      using base::operator();
+      using base::value;
+      using typename base::is_transparent;
+   };
+
+   template<class T>
+   partial_less_equal(T&) -> partial_less_equal<T const&>;
+
+   template<class T>
+   partial_less_equal(T&&) -> partial_less_equal<remove_const_t<remove_reference_t<T>>&&>;
+} // namespace cjdb::ranges
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_LESS_EQUAL_HPP

--- a/include/cjdb/functional/rangecmp/partial_not_equal_to.hpp
+++ b/include/cjdb/functional/rangecmp/partial_not_equal_to.hpp
@@ -1,0 +1,60 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_FUNCTIONAL_RANGECMP_PARTIAL_NOT_EQUAL_TO_HPP
+#define CJDB_FUNCTIONAL_RANGECMP_PARTIAL_NOT_EQUAL_TO_HPP
+
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/detail/functional/rangecmp/partial_equality.hpp"
+#include "cjdb/functional/rangecmp/not_equal_to.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+
+namespace cjdb::ranges {
+   /// \brief Function object for performing comparisons. Applies operator!=.
+   ///
+   /// Unlike `not_equal_to`, `partial_not_equal_to` stores one object, and takes another as a unary
+   /// argument when it is called.
+   ///
+   /// `partial_not_equal_to` is a partial function: that is, we provide a one value now, and others
+   /// when the function is invoked. In keeping up with the 'you don't pay for what you don't use'
+   /// idiom employed by the C++ International Standard, `partial_not_equal_to` only stores a value if
+   /// it is constructed with an rvalue (this is to prevent issues with lifetime management).
+   ///
+   /// If `partial_not_equal_to` is constructed using an lvalue, that lvalue is _referenced_ by the
+   /// partial function. Users must be careful to ensure that use of the partial function does not
+   /// exceed the lifetime of the original object.
+   ///
+   /// \note This is an extension.
+   ///
+   template<EqualityComparable T>
+   class partial_not_equal_to
+   : private detail_partial_equality::partial_equality<T, ranges::not_equal_to> {
+   private:
+      using base = detail_partial_equality::partial_equality<T, ranges::not_equal_to>;
+   public:
+      using base::base;
+      using base::operator();
+      using base::value;
+      using typename base::is_transparent;
+   };
+
+   template<class T>
+   partial_not_equal_to(T&) -> partial_not_equal_to<T const&>;
+
+   template<class T>
+   partial_not_equal_to(T&&) -> partial_not_equal_to<remove_const_t<remove_reference_t<T>>&&>;
+} // namespace cjdb::ranges
+
+#endif // CJDB_FUNCTIONAL_RANGECMP_PARTIAL_NOT_EQUAL_TO_HPP

--- a/test/include/cjdb/test/constexpr_check.hpp
+++ b/test/include/cjdb/test/constexpr_check.hpp
@@ -1,5 +1,5 @@
 //
-//  Copyright Christopher Di Bella
+//  Copyright 2019 Christopher Di Bella
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef CJDB_FUNCTIONAL_HPP
-#define CJDB_FUNCTIONAL_HPP
+#ifndef CJDB_TEST_CONSTEXPR_CHECK
+#define CJDB_TEST_CONSTEXPR_CHECK
+#include <doctest.h>
+#include <type_traits>
 
-// clang-format off
-#include "cjdb/functional/invoke.hpp"
-#include "cjdb/functional/rangecmp.hpp"
-// clang-format on
+#define CJDB_CONSTEXPR_CHECK(...)                 \
+   {                                              \
+      REQUIRE(std::bool_constant<__VA_ARGS__>{}); \
+      CHECK(__VA_ARGS__);                         \
+   }                                              \
 
-#endif // CJDB_FUNCTIONAL_HPP
+#endif // CJDB_TEST_CONSTEXPR_CHECK

--- a/test/include/cjdb/test/functional/rangecmp/is_antisymmetric.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_antisymmetric.hpp
@@ -1,0 +1,66 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_ANTISYMMETRIC_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_ANTISYMMETRIC_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/relation.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_antisymmetric : protected relation<R> {
+   public:
+      constexpr explicit is_antisymmetric(R r)
+         : relation<R>(std::move(r))
+      {}
+
+      /// \brief Checks that the relation is symmetric, with respect to types T and U.
+      /// \param a Parameter to check.
+      /// \param b Parameter to check.
+      /// \returns invoke(r, a, b) == invoke(r, b, a)
+      ///
+      template<class A, cjdb::EqualityComparableWith<A> B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool antisymmetric(A const& a, B const& b) noexcept
+      { return antisymmetric_impl(*this, a, b); }
+
+      /// \brief Checks that the relation is symmetric, with respect to types T and U.
+      /// \param a Parameter to check.
+      /// \param b Parameter to check.
+      /// \returns invoke(r, a, b) == invoke(r, b, a)
+      ///
+      template<class A, cjdb::EqualityComparableWith<A> B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool antisymmetric(A const& a, B const& b) const noexcept
+      { return antisymmetric_impl(*this, a, b); }
+   private:
+      template<class Self, class A, class B>
+      constexpr static bool antisymmetric_impl(Self& self, A const& a, B const& b) noexcept
+      { return (self(a, b) != self(b, a)) or (a == b); }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_ANTISYMMETRIC(r, a, b)                              \
+   {                                                                 \
+      using cjdb_test::is_antisymmetric;                             \
+      CJDB_CONSTEXPR_CHECK(is_antisymmetric{r}.antisymmetric(a, b)); \
+   }                                                                 \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_ANTISYMMETRIC_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_asymmetric.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_asymmetric.hpp
@@ -1,0 +1,60 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_ASYMMETRIC_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_ASYMMETRIC_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/is_antisymmetric.hpp"
+#include "cjdb/test/functional/rangecmp/is_irreflexive.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_asymmetric
+   : private is_irreflexive<R>
+   , private is_antisymmetric<R> {
+   public:
+      constexpr explicit is_asymmetric(R r) noexcept
+         : is_irreflexive<R>(r)
+         , is_antisymmetric<R>(r)
+      {}
+
+      template<class A, cjdb::EqualityComparableWith<A> B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool asymmetric(A const& a, B const& b) noexcept
+      { return asymmetric_impl(*this, a, b); }
+
+      template<class A, cjdb::EqualityComparableWith<A> B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool asymmetric(A const& a, B const& b) const noexcept
+      { return asymmetric_impl(*this, a, b); }
+   private:
+      template<class Self, class A, class B>
+      constexpr bool asymmetric_impl(Self& self, A const& a, B const& b) noexcept
+      { return self.irreflexive(a) and self.irreflexive(b) and self.antisymmetric(a, b); }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_ASYMMETRIC(r, a, b)                           \
+   {                                                           \
+      using cjdb_test::is_asymmetric;                          \
+      CJDB_CONSTEXPR_CHECK(is_asymmetric{r}.asymmetric(a, b)); \
+   }                                                           \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_ASYMMETRIC_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_connex.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_connex.hpp
@@ -1,0 +1,53 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_CONNEX_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_CONNEX_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/relation.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_connex : protected relation<R> {
+   public:
+      constexpr explicit is_connex(R r) noexcept
+         : relation<R>(std::move(r))
+      {}
+
+      template<class A, class B>
+      constexpr bool connex(A const& a, B const& b) noexcept
+      { return connex_impl(*this, a, b); }
+
+      template<class A, class B>
+      constexpr bool connex(A const& a, B const& b) const noexcept
+      { return connex_impl(*this, a, b); }
+   private:
+      template<class Self, class A, class B>
+      constexpr static bool connex_impl(Self& self, A const& a, B const& b) noexcept
+      { return self(a, b) or self(b, a); }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_CONNEX(r, a, b)                       \
+   {                                                   \
+      using cjdb_test::is_connex;                      \
+      CJDB_CONSTEXPR_CHECK(is_connex{r}.connex(a, b)); \
+   }                                                   \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_CONNEX_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_coreflexive.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_coreflexive.hpp
@@ -1,0 +1,64 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_COREFLEXIVE_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_COREFLEXIVE_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/is_reflexive.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_coreflexive : private is_reflexive<R> {
+   public:
+      constexpr explicit is_coreflexive(R r) noexcept
+         : is_reflexive<R>(std::move(r))
+      {}
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<cjdb::EqualityComparable A>
+      requires cjdb::Relation<R, A, A>
+      constexpr bool coreflexive(A const& a) noexcept
+      { return coreflexive_impl(*this, std::move(a)); }
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<cjdb::EqualityComparable A>
+      requires cjdb::Relation<R, A, A>
+      constexpr bool coreflexive(A const& a) const noexcept
+      { return coreflexive_impl(*this, std::move(a)); }
+   private:
+      template<class Self, class A>
+      constexpr static bool coreflexive_impl(Self& self, A const& a)
+      { return self.reflexive(a) and a == a; }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_COREFLEXIVE(r, a)                            \
+   {                                                          \
+      using cjdb_test::is_coreflexive;                        \
+      CJDB_CONSTEXPR_CHECK(is_coreflexive{r}.coreflexive(a)); \
+   }                                                          \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_COREFLEXIVE_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_equivalence.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_equivalence.hpp
@@ -1,0 +1,30 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_EQUIVALENCE_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_EQUIVALENCE_HPP
+
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/is_partial_equivalence.hpp"
+#include "cjdb/test/functional/rangecmp/is_reflexive.hpp"
+
+#define CHECK_IS_EQUIVALENCE(r, a, b, c)        \
+   {                                            \
+      CHECK_IS_PARTIAL_EQUIVALENCE(r, a, b, c); \
+      CHECK_IS_REFLEXIVE(r, a);                 \
+   }                                            \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_EQUIVALENCE_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_euclidean.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_euclidean.hpp
@@ -1,0 +1,55 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_EUCLIDEAN_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_EUCLIDEAN_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/relation.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_euclidean_relation : protected relation<R> {
+   public:
+      constexpr explicit is_euclidean_relation(R r) noexcept
+         : relation<R>(std::move(r))
+      {}
+
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool euclidean(A const& a, B const& b, A const& c) noexcept
+      { return euclidean_impl(*this, a, b, c); }
+
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool euclidean(A const& a, B const& b, A const& c) const noexcept
+      { return euclidean_impl(*this, a, b, c); }
+   private:
+      template<class Self, class A, class B>
+      constexpr static bool euclidean_impl(Self& self, A const& a, B const& b, A const& c) noexcept
+      { return self(a, b) and self(a, c) and self(b, c); }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_EUCLIDEAN_RELATION(r, a, b, c)                          \
+   {                                                                     \
+      using cjdb_test::is_euclidean_relation;                            \
+      CJDB_CONSTEXPR_CHECK(is_euclidean_relation{r}.euclidean(a, b, c)); \
+   }                                                                     \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_EUCLIDEAN_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_irreflexive.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_irreflexive.hpp
@@ -1,0 +1,63 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_IRREFLEXIVE_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_IRREFLEXIVE_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/is_reflexive.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_irreflexive : private is_reflexive<R> {
+   public:
+      constexpr explicit is_irreflexive(R r) noexcept
+         : is_reflexive<R>(r)
+      {}
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<class A>
+      requires cjdb::Relation<R, A, A>
+      constexpr bool irreflexive(A const& a) noexcept
+      { return irreflexive_impl(*this, a); }
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<class A>
+      requires cjdb::Relation<R, A, A>
+      constexpr bool irreflexive(A const& a) const noexcept
+      { return irreflexive_impl(*this, a); }
+   private:
+      template<class Self, class A>
+      constexpr static bool irreflexive_impl(Self& self, A const& a)
+      { return not self.reflexive(a); }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_IRREFLEXIVE(r, a)                            \
+   {                                                          \
+      using cjdb_test::is_irreflexive;                        \
+      CJDB_CONSTEXPR_CHECK(is_irreflexive{r}.irreflexive(a)); \
+   }                                                          \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_IRREFLEXIVE_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_partial_equivalence.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_partial_equivalence.hpp
@@ -1,0 +1,29 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_PARTIAL_EQUIVALENCE_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_PARTIAL_EQUIVALENCE_HPP
+
+#include "cjdb/test/functional/rangecmp/is_symmetric.hpp"
+#include "cjdb/test/functional/rangecmp/is_transitive.hpp"
+
+#define CHECK_IS_PARTIAL_EQUIVALENCE(r, a, b, c) \
+   {                                             \
+      CHECK_IS_SYMMETRIC(r, a, b);               \
+      CHECK_IS_TRANSITIVE(r, a, b, c);           \
+   }                                             \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_PARTIAL_EQUIVALENCE_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_partial_order.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_partial_order.hpp
@@ -1,0 +1,31 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_PARTIAL_ORDER_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_PARTIAL_ORDER_HPP
+
+#include "cjdb/test/functional/rangecmp/is_antisymmetric.hpp"
+#include "cjdb/test/functional/rangecmp/is_reflexive.hpp"
+#include "cjdb/test/functional/rangecmp/is_transitive.hpp"
+
+#define CHECK_IS_PARTIAL_ORDER(r, a, b, c) \
+   {                                       \
+      CHECK_IS_REFLEXIVE(r, a);            \
+      CHECK_IS_ANTISYMMETRIC(r, a, b);     \
+      CHECK_IS_TRANSITIVE(r, a, b, c);     \
+   }                                       \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_PARTIAL_ORDER_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_quasireflexive.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_quasireflexive.hpp
@@ -1,0 +1,63 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_QUASIREFLEXIVE_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_QUASIREFLEXIVE_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/is_reflexive.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_quasireflexive : private is_reflexive<R> {
+   public:
+      constexpr explicit is_quasireflexive(R r)
+         : is_reflexive<R>(std::move(r))
+      {}
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool quasireflexive(A const& a, B const& b) noexcept
+      { return quasireflexive_impl(*this, std::move(a), std::move(b)); }
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool quasireflexive(A const& a, B const& b) const noexcept
+      { return quasireflexive_impl(*this, std::move(a), std::move(b)); }
+   private:
+      template<class Self, class A, class B>
+      constexpr static bool quasireflexive_impl(Self& self, A const& a, B const& b) noexcept
+      { return self(a, b) and self.reflexive(a) and self.reflexive(b); }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_QUASIREFLEXIVE(r, a, b)                                    \
+   {                                                                        \
+      using cjdb_test::is_quasireflexive;                                   \
+      CJDB_CONSTEXPR_CHECK(is_quasireflexive{r}.quasi_reflexive(a, b));     \
+   }                                                                        \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_QUASIREFLEXIVE_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_reflexive.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_reflexive.hpp
@@ -1,0 +1,63 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_REFLEXIVE_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_REFLEXIVE_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/relation.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_reflexive : protected relation<R> {
+   public:
+      constexpr explicit is_reflexive(R r) noexcept
+         : relation<R>(std::move(r))
+      {}
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<class A>
+      requires cjdb::Relation<R, A, A>
+      constexpr bool reflexive(A const& a) noexcept
+      { return reflexive_impl(*this, a); }
+
+      /// \brief Checks that the relation is reflexive, with respect to type T.
+      /// \param a Parameter to check.
+      /// \returns invoke(r, a, a)
+      ///
+      template<class A>
+      requires cjdb::Relation<R, A, A>
+      constexpr bool reflexive(A const& a) const noexcept
+      { return reflexive_impl(*this, a); }
+   private:
+      template<class Self, class A>
+      constexpr static bool reflexive_impl(Self& self, A const& a) noexcept
+      { return self(a, a); }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_REFLEXIVE(r, a)                          \
+   {                                                      \
+      using cjdb_test::is_reflexive;                      \
+      CJDB_CONSTEXPR_CHECK(is_reflexive{r}.reflexive(a)); \
+   }                                                      \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_REFLEXIVE_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_strict_total_order.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_strict_total_order.hpp
@@ -1,0 +1,33 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_STRICT_TOTAL_ORDER_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_STRICT_TOTAL_ORDER_HPP
+
+#include "cjdb/test/functional/rangecmp/is_antisymmetric.hpp"
+#include "cjdb/test/functional/rangecmp/is_connex.hpp"
+#include "cjdb/test/functional/rangecmp/is_irreflexive.hpp"
+#include "cjdb/test/functional/rangecmp/is_transitive.hpp"
+
+#define CHECK_IS_STRICT_TOTAL_ORDER(r, a, b, c) \
+   {                                            \
+      CHECK_IS_IRREFLEXIVE(r, a);               \
+      CHECK_IS_ANTISYMMETRIC(r, a, b);          \
+      CHECK_IS_TRANSITIVE(r, a, b, c);          \
+      CHECK_IS_CONNEX(r, a, b);                 \
+   }                                            \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_STRICT_TOTAL_ORDER_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_symmetric.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_symmetric.hpp
@@ -1,0 +1,65 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_SYMMETRIC_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_SYMMETRIC_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/relation.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_symmetric : protected relation<R> {
+   public:
+      constexpr explicit is_symmetric(R r)
+         : relation<R>(std::move(r))
+      {}
+
+      /// \brief Checks that the relation is symmetric, with respect to types T and U.
+      /// \param a Parameter to check.
+      /// \param b Parameter to check.
+      /// \returns invoke(r, a, b) == invoke(r, b, a)
+      ///
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool symmetric(A const& a, B const& b) noexcept
+      { return symmetric_impl(*this, a, b); }
+
+      /// \brief Checks that the relation is symmetric, with respect to types T and U.
+      /// \param a Parameter to check.
+      /// \param b Parameter to check.
+      /// \returns invoke(r, a, b) == invoke(r, b, a)
+      ///
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool symmetric(A const& a, B const& b) const noexcept
+      { return symmetric_impl(*this, a, b); }
+   private:
+      template<class Self, class A, class B>
+      constexpr static bool symmetric_impl(Self& self, A const& a, B const& b) noexcept
+      { return self(a, b) == self(b, a); }
+   };
+} // namespace cjdb
+
+#define CHECK_IS_SYMMETRIC(r, a, b)                          \
+   {                                                         \
+      using cjdb_test::is_symmetric;                         \
+      CJDB_CONSTEXPR_CHECK(is_symmetric{r}.symmetric(a, b)); \
+   }                                                         \
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_SYMMETRIC_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_transitive.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_transitive.hpp
@@ -1,0 +1,81 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_TRANSITIVE_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_TRANSITIVE_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/relation.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_transitive : protected relation<R> {
+   public:
+      constexpr explicit is_transitive(R r)
+         : relation<R>(std::move(r))
+      {}
+
+      /// \brief Checks that the relation is transitive, with respect to types T and U.
+      /// \param a Parameter to check.
+      /// \param b Parameter to check.
+      /// \returns evaluates as true if, and only if, for some `auto c = a`,
+      ///          `invoke(r, a, b) and invoke(r, b, c) and invoke(r, a, c)` evaluates as true;
+      ///          false otherwise.
+      ///
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool transitive(A const& a, B const& b, A const& c) noexcept
+      { return transitive_impl(*this, a, b, c); }
+
+      /// \brief Checks that the relation is transitive, with respect to types T and U.
+      /// \param a Parameter to check.
+      /// \param b Parameter to check.
+      /// \returns evaluates as true if, and only if, for some `auto c = a`,
+      ///          `invoke(r, a, b) and invoke(r, b, c) and invoke(r, a, c)` evaluates as true;
+      ///          false otherwise.
+      ///
+      template<class A, class B>
+      requires cjdb::Relation<R, A, B>
+      constexpr bool transitive(A const& a, B const& b, A const& c) const noexcept
+      { return transitive_impl(*this, a, b, c); }
+   private:
+      template<class Self, class A, class B>
+      constexpr static bool transitive_impl(Self& self, A const& a, B const& b, A const& c) noexcept
+      {
+         auto const aRb = self(a, b);
+         // [[assert: aRb]];
+         if (not aRb) { throw std::logic_error{"not aRb"}; }
+
+         auto const bRc = self(b, c);
+         // [[assert: bRc]];
+         if (not bRc) { throw std::logic_error{"not bRc"}; }
+
+         auto const aRc = self(a, c);
+         return aRb and bRc and aRc;
+      }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_TRANSITIVE(r, a, b, c)                           \
+   {                                                              \
+      using cjdb_test::is_transitive;                             \
+      CJDB_CONSTEXPR_CHECK(is_transitive{r}.transitive(a, b, c)); \
+   }                                                              \
+
+
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_IS_TRANSITIVE_HPP

--- a/test/include/cjdb/test/functional/rangecmp/is_trichotomy.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/is_trichotomy.hpp
@@ -1,0 +1,59 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_IS_TRICHOTOMY_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_IS_TRICHOTOMY_HPP
+
+#include "cjdb/concepts/callable/relation.hpp"
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include "cjdb/test/functional/rangecmp/relation.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class is_trichotomy : protected relation<R> {
+   public:
+      constexpr explicit is_trichotomy(R r)
+         : relation<R>(std::move(r))
+      {}
+
+      template<class A, cjdb::EqualityComparableWith<A> B>
+      constexpr bool trichotomy(A const& a, B const& b) noexcept
+      { return trichotomy_impl(*this, a, b); }
+
+      template<class A, cjdb::EqualityComparableWith<A> B>
+      constexpr bool trichotomy(A const& a, B const& b) const noexcept
+      { return trichotomy_impl(*this, a, b); }
+   private:
+      template<class Self, class A, class B>
+      constexpr static bool trichotomy_impl(Self& self, A const& a, B const& b) noexcept
+      {
+         auto const aRb = static_cast<bool>(self(a, b));
+         auto const bRa = static_cast<bool>(self(b, a));
+         auto const a_eq_b = static_cast<bool>(a == b);
+         return ((not (aRb and bRa)) xor a_eq_b);
+      }
+   };
+} // namespace cjdb_test
+
+#define CHECK_IS_TRICHOTOMY(r, a, b)                           \
+   {                                                           \
+      using cjdb_test::is_trichotomy;                          \
+      CJDB_CONSTEXPR_CHECK(is_trichotomy{r}.trichotomy(a, b)); \
+   }                                                           \
+
+
+#endif CJDB_TEST_FUNCTIONAL_RANGECMP_IS_TRICHOTOMY_HPP

--- a/test/include/cjdb/test/functional/rangecmp/relation.hpp
+++ b/test/include/cjdb/test/functional/rangecmp/relation.hpp
@@ -1,0 +1,44 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_RELATION_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_RELATION_HPP
+
+#include "cjdb/functional/invoke.hpp"
+#include <utility>
+
+namespace cjdb_test {
+   template<class R>
+   class relation {
+   protected:
+      constexpr explicit relation(R r) noexcept
+         : r_(std::move(r))
+      {}
+
+      ~relation() = default;
+
+      template<class A, class B>
+      constexpr auto operator()(A&& a, B&& b) noexcept
+      { return cjdb::invoke(r_, std::forward<A>(a), std::forward<B>(b)); }
+
+      template<class A, class B>
+      constexpr auto operator()(A&& a, B&& b) const noexcept
+      { return cjdb::invoke(r_, std::forward<A>(a), std::forward<B>(b)); }
+   private:
+      R r_;
+   };
+} // namespace cjdb_test
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_RELATION_HPP

--- a/test/unit/functional/CMakeLists.txt
+++ b/test/unit/functional/CMakeLists.txt
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 add_cjdblib_test(FILENAME invoke.cpp PRIVATE_LINKAGE doctest::doctest)
+add_subdirectory(rangecmp)

--- a/test/unit/functional/rangecmp/CMakeLists.txt
+++ b/test/unit/functional/rangecmp/CMakeLists.txt
@@ -1,0 +1,77 @@
+#
+#  Copyright Christopher Di Bella
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+add_cjdblib_test(FILENAME equal_to.cpp
+   PRIVATE_INCLUDE
+      "${CMAKE_SOURCE_DIR}/test/include"
+   PRIVATE_LINKAGE
+      doctest::doctest
+   PRIVATE_COMPILER_OPTIONS
+      -Wno-error=terminate) # trigger warning as a reminder to enable [[assert]] when it becomes available
+
+add_cjdblib_test(FILENAME not_equal_to.cpp
+   PRIVATE_INCLUDE
+      "${CMAKE_SOURCE_DIR}/test/include"
+   PRIVATE_LINKAGE
+      doctest::doctest
+   PRIVATE_COMPILER_OPTIONS
+      -Wno-error=terminate) # trigger warning as a reminder to enable [[assert]] when it becomes available
+
+add_cjdblib_test(FILENAME less.cpp
+   PRIVATE_INCLUDE
+      "${CMAKE_SOURCE_DIR}/test/include"
+   PRIVATE_LINKAGE
+      doctest::doctest
+   PRIVATE_COMPILER_OPTIONS
+      -Wno-double-promotion
+      -Wno-conversion
+      -Wno-error=terminate) # trigger warning as a reminder to enable [[assert]] when it becomes available
+
+add_cjdblib_test(FILENAME greater.cpp
+   PRIVATE_INCLUDE
+      "${CMAKE_SOURCE_DIR}/test/include"
+   PRIVATE_LINKAGE
+      doctest::doctest
+   PRIVATE_COMPILER_OPTIONS
+      -Wno-double-promotion
+      -Wno-conversion
+      -Wno-error=terminate) # trigger warning as a reminder to enable [[assert]] when it becomes available
+
+add_cjdblib_test(FILENAME less_equal.cpp
+   PRIVATE_INCLUDE
+      "${CMAKE_SOURCE_DIR}/test/include"
+   PRIVATE_LINKAGE
+      doctest::doctest
+   PRIVATE_COMPILER_OPTIONS
+      -Wno-double-promotion
+      -Wno-conversion
+      -Wno-error=terminate) # trigger warning as a reminder to enable [[assert]] when it becomes available
+
+add_cjdblib_test(FILENAME greater_equal.cpp
+   PRIVATE_INCLUDE
+      "${CMAKE_SOURCE_DIR}/test/include"
+   PRIVATE_LINKAGE
+      doctest::doctest
+   PRIVATE_COMPILER_OPTIONS
+      -Wno-double-promotion
+      -Wno-conversion
+      -Wno-error=terminate) # trigger warning as a reminder to enable [[assert]] when it becomes available
+
+add_cjdblib_test(FILENAME partial_equal_to.cpp PRIVATE_LINKAGE doctest::doctest)
+# add_cjdblib_test(FILENAME partial_not_equal_to.cpp PRIVATE_LINKAGE doctest::doctest)
+add_cjdblib_test(FILENAME partial_less.cpp PRIVATE_LINKAGE doctest::doctest)
+# add_cjdblib_test(FILENAME partial_greater.cpp PRIVATE_LINKAGE doctest::doctest)
+# add_cjdblib_test(FILENAME partial_less_equal.cpp PRIVATE_LINKAGE doctest::doctest)
+# add_cjdblib_test(FILENAME partial_greater_equal.cpp PRIVATE_LINKAGE doctest::doctest)

--- a/test/unit/functional/rangecmp/equal_to.cpp
+++ b/test/unit/functional/rangecmp/equal_to.cpp
@@ -1,0 +1,58 @@
+//
+//  Copyright 2018 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/equal_to.hpp"
+
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/test/functional/rangecmp/is_equivalence.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include <doctest.h>
+#include <string_view>
+
+TEST_CASE("Test [rangecmp.equal_to]") {
+   using cjdb::ranges::equal_to;
+   using namespace std::string_view_literals;
+
+   REQUIRE(equal_to::is_transparent{});
+
+   constexpr auto hello = "hello"sv;
+   constexpr auto goodbye = "goodbye"sv;
+
+   SUBCASE("shows equal_to is an equivalence relation") {
+      CHECK_IS_EQUIVALENCE(equal_to{}, 0, 0, 0);
+      CHECK_IS_EQUIVALENCE(equal_to{}, 0, 0.0, 0);
+      CHECK_IS_EQUIVALENCE(equal_to{}, 0.0, 0, 0.0);
+
+      CHECK_IS_EQUIVALENCE(equal_to{}, hello, hello, hello);
+   }
+
+   SUBCASE("shows equal_to works for same-type equality") {
+      CJDB_CONSTEXPR_CHECK(equal_to{}(0, 0));
+      CJDB_CONSTEXPR_CHECK(not equal_to{}(0, 1));
+
+      CJDB_CONSTEXPR_CHECK(equal_to{}(hello, hello));
+      CJDB_CONSTEXPR_CHECK(not equal_to{}(hello, goodbye));
+   }
+
+   SUBCASE("shows equal_to works for cross-type equality") {
+      CJDB_CONSTEXPR_CHECK(equal_to{}(1, 1.0));
+      CJDB_CONSTEXPR_CHECK(not equal_to{}(1, 1.5)); // int is promoted to double
+      CJDB_CONSTEXPR_CHECK(not equal_to{}(1, 2.6)); // outright not equal
+
+      CJDB_CONSTEXPR_CHECK(equal_to{}(hello, hello.data()));
+      CJDB_CONSTEXPR_CHECK(not equal_to{}(hello, goodbye.data()));
+   }
+}

--- a/test/unit/functional/rangecmp/greater.cpp
+++ b/test/unit/functional/rangecmp/greater.cpp
@@ -1,0 +1,60 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/greater.hpp"
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/test/functional/rangecmp/is_strict_total_order.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include <doctest.h>
+#include <string_view>
+
+
+TEST_CASE("Test [rangecmp.greater]") {
+   using cjdb::ranges::greater;
+   using namespace std::string_view_literals;
+
+   REQUIRE(greater::is_transparent{});
+
+   constexpr auto hello = "hello"sv;
+   constexpr auto konnichiwa = "konnichiwa"sv; // it's infuriating that "こんにちは" <= "hello" at
+                                               // compile-time.
+
+   SUBCASE("shows greater is a strict total order") {
+      CHECK_IS_STRICT_TOTAL_ORDER(greater{}, 2, 1, 0);
+      CHECK_IS_STRICT_TOTAL_ORDER(greater{}, 2, 1.0, 0);
+      CHECK_IS_STRICT_TOTAL_ORDER(greater{}, 2, 1.5, 1);
+
+      CHECK_IS_STRICT_TOTAL_ORDER(greater{}, "c"sv, "ab"sv, "a"sv);
+      CHECK_IS_STRICT_TOTAL_ORDER(greater{}, "c"sv, "ab"sv, "a"sv);
+   }
+
+   SUBCASE("shows greater works for same-type ordering") {
+      CJDB_CONSTEXPR_CHECK(greater{}(4, 3));
+      CJDB_CONSTEXPR_CHECK(not greater{}(3, 40));
+
+      CJDB_CONSTEXPR_CHECK(greater{}(konnichiwa, hello));
+      CJDB_CONSTEXPR_CHECK(not greater{}(hello, konnichiwa));
+   }
+
+   SUBCASE("shows greater works for cross-type ordering") {
+      CJDB_CONSTEXPR_CHECK(greater{}(4, 3.0));
+      CJDB_CONSTEXPR_CHECK(not greater{}(3, 3.9999)); // int promoted to double
+
+      CJDB_CONSTEXPR_CHECK(greater{}(konnichiwa.data(), hello));
+      CJDB_CONSTEXPR_CHECK(not greater{}(hello, konnichiwa.data()));
+   }
+}

--- a/test/unit/functional/rangecmp/greater_equal.cpp
+++ b/test/unit/functional/rangecmp/greater_equal.cpp
@@ -1,0 +1,64 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/greater_equal.hpp"
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/test/functional/rangecmp/is_partial_order.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include <doctest.h>
+#include <string_view>
+
+
+TEST_CASE("Test [rangecmp.greater_equal]") {
+   using cjdb::ranges::greater_equal;
+   using namespace std::string_view_literals;
+
+   REQUIRE(greater_equal::is_transparent{});
+
+   constexpr auto hello = "hello"sv;
+   constexpr auto konnichiwa = "konnichiwa"sv; // it's infuriating that "こんにちは" <= "hello" at
+                                               // compile-time.
+
+   SUBCASE("shows greater_equal is a partial order") {
+      CHECK_IS_PARTIAL_ORDER(greater_equal{}, 2, 1, 0);
+      CHECK_IS_PARTIAL_ORDER(greater_equal{}, 2, 1.0, 0);
+      CHECK_IS_PARTIAL_ORDER(greater_equal{}, 2, 1.5, 1);
+
+      CHECK_IS_PARTIAL_ORDER(greater_equal{}, "c"sv, "ab"sv, "a"sv);
+      CHECK_IS_PARTIAL_ORDER(greater_equal{}, "c"sv, "ab"sv, "a"sv);
+   }
+
+   SUBCASE("shows greater_equal works for same-type ordering") {
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(30, 30));
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(4, 3));
+      CJDB_CONSTEXPR_CHECK(not greater_equal{}(3, 40));
+
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(hello, hello));
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(konnichiwa, hello));
+      CJDB_CONSTEXPR_CHECK(not greater_equal{}(hello, konnichiwa));
+   }
+
+   SUBCASE("shows greater_equal works for cross-type ordering") {
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(3.0, 3));
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(4, 3.0));
+      CJDB_CONSTEXPR_CHECK(not greater_equal{}(3, 3.9999)); // int promoted to double
+
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(hello, hello.data()));
+      CJDB_CONSTEXPR_CHECK(greater_equal{}(konnichiwa.data(), hello));
+      CJDB_CONSTEXPR_CHECK(not greater_equal{}(hello, konnichiwa.data()));
+   }
+}

--- a/test/unit/functional/rangecmp/less.cpp
+++ b/test/unit/functional/rangecmp/less.cpp
@@ -1,0 +1,60 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/less.hpp"
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/test/functional/rangecmp/is_strict_total_order.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include <doctest.h>
+#include <string_view>
+
+
+TEST_CASE("Test [rangecmp.less]") {
+   using cjdb::ranges::less;
+   using namespace std::string_view_literals;
+
+   REQUIRE(less::is_transparent{});
+
+   constexpr auto hello = "hello"sv;
+   constexpr auto konnichiwa = "konnichiwa"sv; // it's infuriating that "こんにちは" <= "hello" at
+                                               // compile-time.
+
+   SUBCASE("shows less is a strict total order") {
+      CHECK_IS_STRICT_TOTAL_ORDER(less{}, 0, 1, 2);
+      CHECK_IS_STRICT_TOTAL_ORDER(less{}, 0, 1.0, 2);
+      CHECK_IS_STRICT_TOTAL_ORDER(less{}, 1, 1.5, 2);
+
+      CHECK_IS_STRICT_TOTAL_ORDER(less{}, "a"sv, "ab"sv, "c"sv);
+      CHECK_IS_STRICT_TOTAL_ORDER(less{}, "a"sv, "ab", "c"sv);
+   }
+
+   SUBCASE("shows less works for same-type ordering") {
+      CJDB_CONSTEXPR_CHECK(less{}(3, 4));
+      CJDB_CONSTEXPR_CHECK(not less{}(40, 3));
+
+      CJDB_CONSTEXPR_CHECK(less{}(hello, konnichiwa));
+      CJDB_CONSTEXPR_CHECK(not less{}(konnichiwa, hello));
+   }
+
+   SUBCASE("shows less works for cross-type ordering") {
+      CJDB_CONSTEXPR_CHECK(less{}(3.0, 4));
+      CJDB_CONSTEXPR_CHECK(not less{}(3.9999, 3)); // int promoted to double
+
+      CJDB_CONSTEXPR_CHECK(less{}(hello, konnichiwa.data()));
+      CJDB_CONSTEXPR_CHECK(not less{}(konnichiwa.data(), hello));
+   }
+}

--- a/test/unit/functional/rangecmp/less_equal.cpp
+++ b/test/unit/functional/rangecmp/less_equal.cpp
@@ -1,0 +1,64 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/less_equal.hpp"
+
+#include "cjdb/concepts/comparison/stricttotallyordered.hpp"
+#include "cjdb/test/functional/rangecmp/is_partial_order.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include <doctest.h>
+#include <string_view>
+
+
+TEST_CASE("Test [rangecmp.less_equal]") {
+   using cjdb::ranges::less_equal;
+   using namespace std::string_view_literals;
+
+   REQUIRE(less_equal::is_transparent{});
+
+   constexpr auto hello = "hello"sv;
+   constexpr auto konnichiwa = "konnichiwa"sv; // it's infuriating that "こんにちは" <= "hello" at
+                                               // compile-time.
+
+   SUBCASE("shows less_equal is a partial order") {
+      CHECK_IS_PARTIAL_ORDER(less_equal{}, 0, 1, 2);
+      CHECK_IS_PARTIAL_ORDER(less_equal{}, 0, 1.0, 2);
+      CHECK_IS_PARTIAL_ORDER(less_equal{}, 1, 1.5, 2);
+
+      CHECK_IS_PARTIAL_ORDER(less_equal{}, "a"sv, "ab"sv, "c"sv);
+      CHECK_IS_PARTIAL_ORDER(less_equal{}, "a"sv, "ab"sv, "c"sv);
+   }
+
+   SUBCASE("shows less_equal works for same-type ordering") {
+      CJDB_CONSTEXPR_CHECK(less_equal{}(30, 30));
+      CJDB_CONSTEXPR_CHECK(less_equal{}(3, 4));
+      CJDB_CONSTEXPR_CHECK(not less_equal{}(40, 3));
+
+      CJDB_CONSTEXPR_CHECK(less_equal{}(hello, hello));
+      CJDB_CONSTEXPR_CHECK(less_equal{}(hello, konnichiwa));
+      CJDB_CONSTEXPR_CHECK(not less_equal{}(konnichiwa, hello));
+   }
+
+   SUBCASE("shows less_equal works for cross-type ordering") {
+      CJDB_CONSTEXPR_CHECK(less_equal{}(3, 3.0));
+      CJDB_CONSTEXPR_CHECK(less_equal{}(3.0, 4));
+      CJDB_CONSTEXPR_CHECK(not less_equal{}(3.9999, 3)); // int promoted to double
+
+      CJDB_CONSTEXPR_CHECK(less_equal{}(hello, hello.data()));
+      CJDB_CONSTEXPR_CHECK(less_equal{}(hello, konnichiwa.data()));
+      CJDB_CONSTEXPR_CHECK(not less_equal{}(konnichiwa.data(), hello));
+   }
+}

--- a/test/unit/functional/rangecmp/not_equal_to.cpp
+++ b/test/unit/functional/rangecmp/not_equal_to.cpp
@@ -1,0 +1,52 @@
+//
+//  Copyright 2018 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/not_equal_to.hpp"
+
+#include "cjdb/concepts/comparison/equalitycomparable.hpp"
+#include "cjdb/test/functional/rangecmp/is_irreflexive.hpp"
+#include "cjdb/test/functional/rangecmp/is_symmetric.hpp"
+#include "cjdb/test/constexpr_check.hpp"
+#include <doctest.h>
+#include <string_view>
+#include <utility>
+
+TEST_CASE("Test [rangecmp.not_equal_to]") {
+   using cjdb::ranges::not_equal_to;
+   using namespace std::string_view_literals;
+
+   REQUIRE(not_equal_to::is_transparent{});
+
+   constexpr auto hello = "hello"sv;
+
+   SUBCASE("Checks not_equal_to is irreflexive and symmetric") {
+      CHECK_IS_IRREFLEXIVE(not_equal_to{}, 0);
+      CHECK_IS_IRREFLEXIVE(not_equal_to{}, hello);
+   }
+
+   SUBCASE("Checks not_equal_to works for same-type inequality") {
+      CJDB_CONSTEXPR_CHECK(not_equal_to{}(0, 1));
+
+      CJDB_CONSTEXPR_CHECK(not not_equal_to{}(0, 0));
+   }
+
+   SUBCASE("Checks not_equal_to works for cross-type inequality") {
+      CJDB_CONSTEXPR_CHECK(not_equal_to{}(1, 1.5)); // int is promoted to double
+      CJDB_CONSTEXPR_CHECK(not_equal_to{}(1, 2.6)); // just outright not equal
+
+      CJDB_CONSTEXPR_CHECK(not not_equal_to{}(1, 1.0));
+   }
+}

--- a/test/unit/functional/rangecmp/partial_equal_to.cpp
+++ b/test/unit/functional/rangecmp/partial_equal_to.cpp
@@ -1,0 +1,44 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/partial_equal_to.hpp"
+
+#include "cjdb/concepts/core/same.hpp"
+#include <doctest.h>
+#include "partial_test.hpp"
+#include <utility>
+
+
+TEST_CASE("Test [cjdb.ext.rangecmp.partial_equal_to]") {
+   auto ints = ::cjdb_test::generate_ints();
+   using difference_type = decltype(ints)::difference_type;
+
+   using cjdb::ranges::equal_to;
+   using cjdb::ranges::partial_equal_to;
+
+   cjdb_test::check_iterators_match(ints, partial_equal_to{-1}, equal_to{});
+   cjdb_test::check_iterators_match(ints, partial_equal_to{ 0}, equal_to{});
+   cjdb_test::check_iterators_match(ints, partial_equal_to{ 4}, equal_to{});
+   // FIXME(cjdb): s/static_cast<difference_type>(std::size(ints))/cjdb::ranges::distance(ints)/
+   auto const distance = static_cast<difference_type>(std::size(ints));
+   cjdb_test::check_iterators_match(ints, partial_equal_to{distance - 1}, equal_to{});
+   cjdb_test::check_iterators_match(ints, partial_equal_to{distance}, equal_to{});
+
+   static_assert(not cjdb::Same<decltype(partial_equal_to{ints}),
+                                decltype(partial_equal_to{std::vector<int>{}})>);
+   static_assert(cjdb::Same<decltype(partial_equal_to{ints}),
+                            decltype(partial_equal_to{std::as_const(ints)})>);
+}

--- a/test/unit/functional/rangecmp/partial_less.cpp
+++ b/test/unit/functional/rangecmp/partial_less.cpp
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef CJDB_FUNCTIONAL_HPP
-#define CJDB_FUNCTIONAL_HPP
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cjdb/functional/rangecmp/partial_equal_to.hpp"
 
-// clang-format off
-#include "cjdb/functional/invoke.hpp"
-#include "cjdb/functional/rangecmp.hpp"
-// clang-format on
+#include <algorithm> // FIXME(cjdb): change to "cjdb/algorithm/find_if.hpp"
+#include <doctest.h>
+#include <iterator>  // FIXME(cjdb): change to "cjdb/range/access.hpp"
+#include <numeric>   // FIXME(cjdb): change to "cjdb/range/iota_view.hpp"
+#include <vector>
 
-#endif // CJDB_FUNCTIONAL_HPP
+TEST_CASE("Test [cjdb.ext.rangecmp.less]") {
+
+}

--- a/test/unit/functional/rangecmp/partial_test.hpp
+++ b/test/unit/functional/rangecmp/partial_test.hpp
@@ -1,0 +1,49 @@
+//
+//  Copyright Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef CJDB_TEST_FUNCTIONAL_RANGECMP_PARTIAL_TEST_HPP
+#define CJDB_TEST_FUNCTIONAL_RANGECMP_PARTIAL_TEST_HPP
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <algorithm> // FIXME(cjdb): change to "cjdb/algorithm/find_if.hpp"
+#include <doctest.h>
+#include <iterator>  // FIXME(cjdb): change to "cjdb/range/access.hpp"
+#include <numeric>   // FIXME(cjdb): change to "cjdb/range/iota_view.hpp"
+#include <vector>
+
+namespace cjdb_test {
+   // FIXME(cjdb): change function to `view::iota | view::take` when it's available
+   inline std::vector<int> generate_ints(int const size = 10) noexcept {
+      auto result = std::vector<int>(static_cast<std::vector<int>::size_type>(size));
+      std::iota(std::begin(result), std::end(result), 0);
+      return result;
+   }
+
+   // FIXME(cjdb): s/class R/InputRange R/
+   // FIXME(cjdb): s/class PartialPred/IndirectUnaryInvocable<range_value_t<R>>/
+   // FIXME(cjdb): s/class Pred/IndirectUnaryInvocable<range_value_t<R>>/
+   template<class R, class PartialPred, class Pred>
+   void check_iterators_match(R&& r, PartialPred partial_pred, Pred pred) noexcept {
+      // FIXME(cjdb): s/std::find_if(std::begin(r), std::end(r)/cjdb::ranges::find_if(r/
+      auto const actual = std::find_if(std::begin(r), std::end(r), partial_pred);
+
+      // FIXME(cjdb): s/std::find_if(std::begin(r), std::end(r)/cjdb::ranges::find_if(r/
+      auto const expected = std::find_if(std::begin(r), std::end(r),
+         [&](auto const& x) noexcept { return pred(partial_pred.value(), x); });
+      CHECK(actual == expected);
+   }
+} // namespace cjdb_test
+
+#endif // CJDB_TEST_FUNCTIONAL_RANGECMP_PARTIAL_TEST_HPP


### PR DESCRIPTION
closes #10 adds comparison function objects and tests

[range.cmp] describes the C++20 comparison function objects, which are both concept-aware and offer stronger type-safety by removing the pre-declared comparison type.

This commit adds everything in [range.cmp], as well as a thorough suite of tests for binary relations.

See https://timsong-cpp.github.io/cppwp/range.cmp.