### PR TITLE
adds [iterator.assoc.types]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 # Copyright (c) Christopher Di Bella.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-Checks: 'bugprone-*,clang-analyzer-*,-clang-diagnostic-missing-prototypes,-clang-diagnostic-unused-command-line-argument,-cert-dcl21-cpp,-cert-dcl59-cpp,cppcoreguildelines-*,google-*,-google-build-namespaces,-google-build-using-namespace,-google-runtime-int,-google-runtime-references,misc-*,modernize-*,-modernize-use-trailing-return-type,performance-*,portability-*,readability-*,-readability-function-size,-readability-named-parameter,-readability-uppercase-literal-suffix'
+Checks: 'bugprone-*,clang-analyzer-*,-clang-diagnostic-missing-prototypes,-clang-diagnostic-unused-command-line-argument,-cert-dcl21-cpp,-cert-dcl59-cpp,cppcoreguildelines-*,google-*,-google-build-namespaces,-google-build-using-namespace,-google-runtime-int,-google-readability-braces-around-statements,-google-runtime-references,misc-*,modernize-*,-modernize-use-trailing-return-type,performance-*,portability-*,readability-*,-readability-avoid-const-params-in-decls,-readability-braces-around-statements,-readability-function-size,-readability-named-parameter,-readability-uppercase-literal-suffix'
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'cjdb/.*'
 

--- a/include/cjdb/detail/iterator/incrementable_traits.hpp
+++ b/include/cjdb/detail/iterator/incrementable_traits.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_DETAIL_ITERATOR_INCREMENTABLE_TRAITS_HPP
+#define CJDB_DETAIL_ITERATOR_INCREMENTABLE_TRAITS_HPP
+
+#include "cjdb/concepts/core/integral.hpp"
+#include "cjdb/iterator/iterator_traits.hpp"
+#include "cjdb/type_traits/is_primary.hpp"
+
+namespace cjdb {
+	template<typename> struct incrementable_traits;
+} // namespace cjdb
+
+namespace cjdb::detail_incrementable_traits {
+	template<typename T>
+	concept has_difference_type = requires { typename T::difference_type; };
+
+	template<typename T>
+	concept has_integral_minus =
+		(not has_difference_type<T>) and
+		requires(T const& a, T const& b) {
+			{ a - b } -> integral;
+		};
+
+	template<typename I>
+	struct extract_incrementable_traits {
+		using type = typename iterator_traits<I>::difference_type;
+	};
+
+	template<typename I>
+	requires is_primary<iterator_traits<I>>
+	struct extract_incrementable_traits<I> {
+		using type = typename incrementable_traits<I>::difference_type;
+	};
+} // namespace cjdb::detail_incrementable_traits
+
+#endif // CJDB_DETAIL_ITERATOR_INCREMENTABLE_TRAITS

--- a/include/cjdb/detail/iterator/iterator_traits.hpp
+++ b/include/cjdb/detail/iterator/iterator_traits.hpp
@@ -1,0 +1,113 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_ITERATOR_DETAIL_ITERATOR_TRAITS_HPP
+#define CJDB_ITERATOR_DETAIL_ITERATOR_TRAITS_HPP
+
+#include "cjdb/detail/iterator/legacy_iterator.hpp"
+#include <iterator>
+
+namespace cjdb {
+	template<typename> struct incrementable_traits;
+	template<typename> struct readable_traits;
+} // namespace cjdb
+
+namespace cjdb::detail_iterator_traits {
+	template<typename I>
+	struct extract_pointer_member {
+		using type = void;
+	};
+
+	template<typename I>
+	concept has_pointer_member = requires { typename I::pointer; };
+
+	template<has_pointer_member I>
+	struct extract_pointer_member<I> {
+		using type = typename I::pointer;
+	};
+
+	template<typename I>
+	concept has_arrow =
+		detail_legacy_iterator::legacy_input_iterator<I> and
+		(not has_pointer_member<I>) and
+		requires(I& i) {
+			i.operator->();
+		};
+
+	template<has_arrow I>
+	struct extract_pointer_member<I> {
+		using type = decltype(std::declval<I&>().operator->());
+	};
+
+	template<typename I>
+	concept has_reference_member = requires { typename I::reference; };
+
+	template<typename I>
+	struct extract_reference_member {
+		using type = iter_reference_t<I>;
+	};
+
+	template<has_reference_member I>
+	struct extract_reference_member<I> {
+		using type = typename I::reference;
+	};
+
+	template<typename I>
+	struct deduce_iterator_category {
+		using type = std::input_iterator_tag;
+	};
+
+	template<detail_legacy_iterator::legacy_forward_iterator I>
+	struct deduce_iterator_category<I> {
+		using type = std::forward_iterator_tag;
+	};
+
+	template<detail_legacy_iterator::legacy_bidirectional_iterator I>
+	struct deduce_iterator_category<I> {
+		using type = std::bidirectional_iterator_tag;
+	};
+
+	template<detail_legacy_iterator::legacy_random_access_iterator I>
+	struct deduce_iterator_category<I> {
+		using type = std::random_access_iterator_tag;
+	};
+
+	template<typename I>
+	struct extract_iterator_category_member : deduce_iterator_category<I> {};
+
+	template<typename I>
+	concept has_iterator_category_member = requires { typename I::iterator_category; };
+
+	template<has_iterator_category_member I>
+	struct extract_iterator_category_member<I> {
+		using type = typename I::iterator_category;
+	};
+
+	template<typename I>
+	concept specifies_members =
+		not detail_legacy_iterator::legacy_iterator<I> and
+		has_reference_member<I> and
+		has_iterator_category_member<I> and
+		requires {
+			typename I::difference_type;
+			typename I::value_type;
+		};
+
+	template<typename I>
+	inline constexpr auto valid_incrementable_traits = requires {
+		typename incrementable_traits<I>::difference_type;
+	};
+
+	template<typename>
+	struct extract_difference_type {
+		using type = void;
+	};
+
+	template<typename I>
+	requires valid_incrementable_traits<I>
+	struct extract_difference_type<I> {
+		using type = typename incrementable_traits<I>::difference_type;
+	};
+} // namespace cjdb::detail_iterator_traits
+
+#endif // CJDB_ITERATOR_DETAIL_ITERATOR_TRAITS_HPP

--- a/include/cjdb/detail/iterator/legacy_iterator.hpp
+++ b/include/cjdb/detail/iterator/legacy_iterator.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_DETAIL_ITERATOR_LEGACY_ITERATOR_HPP
+#define CJDB_DETAIL_ITERATOR_LEGACY_ITERATOR_HPP
+
+#include "cjdb/concepts/comparison/equality_comparable.hpp"
+#include "cjdb/concepts/comparison/totally_ordered.hpp"
+#include "cjdb/concepts/core/constructible_from.hpp"
+#include "cjdb/concepts/core/convertible_to.hpp"
+#include "cjdb/concepts/core/integral.hpp"
+#include "cjdb/concepts/core/same_as.hpp"
+#include "cjdb/concepts/object/copyable.hpp"
+#include "cjdb/detail/iterator/reference.hpp"
+#include "cjdb/iterator/reference.hpp"
+#include "cjdb/type_traits/common_reference.hpp"
+
+namespace cjdb {
+	template<typename> struct incrementable_traits;
+	template<typename> struct readable_traits;
+} // namespace cjdb
+
+namespace cjdb::detail_legacy_iterator {
+	template<class I>
+	concept legacy_iterator =
+		copyable<I> and
+		requires(I i) {
+			{   *i } -> detail_iterator_reference::can_reference;
+			{  ++i } -> same_as<I&>;
+			{ *i++ } -> detail_iterator_reference::can_reference;
+		};
+
+	template<class I>
+	concept legacy_input_iterator =
+		legacy_iterator<I>
+		and equality_comparable<I>
+		and requires(I i) {
+			typename incrementable_traits<I>::difference_type;
+			typename readable_traits<I>::value_type;
+			typename common_reference_t<iter_reference_t<I>&&,
+			                            typename readable_traits<I>::value_type&>;
+			typename common_reference_t<decltype(*i++)&&,
+			                            typename readable_traits<I>::value_type&>;
+			requires signed_integral<typename incrementable_traits<I>::difference_type>;
+		};
+
+	template<class I>
+	concept legacy_forward_iterator =
+		legacy_input_iterator<I> and
+		constructible_from<I> and
+		is_lvalue_reference_v<iter_reference_t<I>> and
+		same_as<remove_cvref_t<iter_reference_t<I>>, typename readable_traits<I>::value_type> and
+		requires(I i) {
+			{  i++ } -> convertible_to<I const&>;
+			{ *i++ } -> same_as<iter_reference_t<I>>;
+		};
+
+	template<class I>
+	concept legacy_bidirectional_iterator =
+		legacy_forward_iterator<I> and
+		requires(I i) {
+			{  --i } -> same_as<I&>;
+			{  i-- } -> convertible_to<I const&>;
+			{ *i-- } -> same_as<iter_reference_t<I>>;
+		};
+
+	template<class I>
+	concept legacy_random_access_iterator =
+		legacy_bidirectional_iterator<I> and
+		totally_ordered<I> and
+		requires(I i, I j, typename incrementable_traits<I>::difference_type n) {
+			{ i += n } -> same_as<I&>;
+			{ i -= n } -> same_as<I&>;
+			{ i +  n } -> same_as<I>;
+			{ n +  i } -> same_as<I>;
+			{ i -  n } -> same_as<I>;
+			{ i -  j } -> same_as<decltype(n)>;
+			{  i[n]  } -> convertible_to<iter_reference_t<I>>;
+		};
+} // namespace cjdb::detail_legacy_iterator
+
+#endif // CJDB_DETAIL_ITERATOR_LEGACY_ITERATOR_HPP

--- a/include/cjdb/detail/iterator/readable_traits.hpp
+++ b/include/cjdb/detail/iterator/readable_traits.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_DETAIL_ITERATOR_READABLE_TRAITS_HPP
+#define CJDB_DETAIL_ITERATOR_READABLE_TRAITS_HPP
+
+#include "cjdb/iterator/iterator_traits.hpp"
+#include "cjdb/type_traits/is_primary.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+
+namespace cjdb {
+	template<typename> struct readable_traits;
+} // namespace cjdb
+
+namespace cjdb::detail_readable_traits {
+	template<typename> struct cond_value_type {};
+
+	template<typename T>
+	requires is_object_v<T>
+	struct cond_value_type<T> {
+		using value_type = remove_cv_t<T>;
+	};
+
+	template<typename T>
+	concept has_value_type = requires { typename T::value_type; };
+
+	template<typename T>
+	concept has_element_type = requires { typename T::element_type; };
+
+	template<typename I>
+	struct extract_readable_traits {
+		using type = typename iterator_traits<I>::value_type;
+	};
+
+	template<typename I>
+	requires is_primary<iterator_traits<I>>
+	struct extract_readable_traits<I> {
+		using type = typename readable_traits<I>::value_type;
+	};
+} // namespace cjdb::detail_readable_traits
+
+#endif // CJDB_DETAIL_ITERATOR_READABLE_TRAITS_HPP

--- a/include/cjdb/detail/iterator/reference.hpp
+++ b/include/cjdb/detail/iterator/reference.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_DETAIL_ITERATOR_REFERENCE_HPP
+#define CJDB_DETAIL_ITERATOR_REFERENCE_HPP
+
+namespace cjdb::detail_iterator_reference {
+	template<typename T>
+	using with_reference = T&;
+
+	template<typename T>
+	concept can_reference = requires {
+		typename with_reference<T>;
+	};
+
+	template<typename T>
+	concept dereferenceable = requires(T& t) {
+		{ *t } -> can_reference; // not required to be equality-preserving
+	};
+} // namespace cjdb::detail_iterator_reference
+
+#endif // CJDB_DETAIL_ITERATOR_REFERENCE_HPP

--- a/include/cjdb/detail/type_traits/primary_template.hpp
+++ b/include/cjdb/detail/type_traits/primary_template.hpp
@@ -1,0 +1,11 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_DETAIL_TYPE_TRAITS_PRIMARY_TEMPLATE_HPP
+#define CJDB_DETAIL_TYPE_TRAITS_PRIMARY_TEMPLATE_HPP
+
+namespace cjdb::detail_primary_template {
+	struct primary_template {};
+} // namespace cjdb::detail_primary_template
+
+#endif // CJDB_DETAIL_TYPE_TRAITS_PRIMARY_TEMPLATE_HPP

--- a/include/cjdb/iterator/incrementable_traits.hpp
+++ b/include/cjdb/iterator/incrementable_traits.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_ITERATOR_INCREMENTABLE_TRAITS_HPP
+#define CJDB_ITERATOR_INCREMENTABLE_TRAITS_HPP
+
+#include "cjdb/concepts/core/integral.hpp"
+#include "cjdb/detail/iterator/incrementable_traits.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+namespace cjdb {
+	// [incrementable.traits]
+	template<typename>
+	struct incrementable_traits {};
+
+	template<typename T>
+	requires is_object_v<T>
+	struct incrementable_traits<T*> {
+		using difference_type = std::ptrdiff_t;
+	};
+
+	template<typename I>
+	struct incrementable_traits<I const> : incrementable_traits<I> {};
+
+	template<detail_incrementable_traits::has_difference_type T>
+	struct incrementable_traits<T> {
+		using difference_type = typename T::difference_type;
+	};
+
+	template<detail_incrementable_traits::has_integral_minus T>
+	struct incrementable_traits<T> {
+		using difference_type = make_signed_t<decltype(std::declval<T>() - std::declval<T>())>;
+	};
+
+	template<typename T>
+	using iter_difference_t = _t<detail_incrementable_traits::extract_incrementable_traits<T>>;
+} // namespace cjdb
+
+#endif // CJDB_ITERATOR_INCREMENTABLE_TRAITS_HPP

--- a/include/cjdb/iterator/iterator_traits.hpp
+++ b/include/cjdb/iterator/iterator_traits.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_ITERATOR_ITERATOR_TRAITS_HPP
+#define CJDB_ITERATOR_ITERATOR_TRAITS_HPP
+
+#include "cjdb/detail/iterator/iterator_traits.hpp"
+#include "cjdb/detail/iterator/legacy_iterator.hpp"
+#include "cjdb/detail/type_traits/primary_template.hpp"
+#include <iterator>
+
+namespace cjdb {
+	template<typename>
+	struct iterator_traits : private detail_primary_template::primary_template {};
+
+	template<detail_iterator_traits::specifies_members I>
+	struct iterator_traits<I> : private detail_primary_template::primary_template {
+		using iterator_category = typename I::iterator_category;
+		using value_type        = typename I::value_type;
+		using difference_type   = typename I::difference_type;
+		using pointer           = _t<detail_iterator_traits::extract_pointer_member<I>>;
+		using reference         = typename I::reference;
+	};
+
+	template<detail_legacy_iterator::legacy_iterator I>
+	struct iterator_traits<I> : private detail_primary_template::primary_template {
+		using iterator_category = std::output_iterator_tag;
+		using value_type        = void;
+		using difference_type   = _t<detail_iterator_traits::extract_difference_type<I>>;
+		using pointer           = void;
+		using reference         = void;
+	};
+
+	template<detail_legacy_iterator::legacy_input_iterator I>
+	struct iterator_traits<I> : private detail_primary_template::primary_template {
+		using iterator_category = _t<detail_iterator_traits::extract_iterator_category_member<I>>;
+		using value_type        = typename readable_traits<I>::value_type;
+		using difference_type   = typename incrementable_traits<I>::difference_type;
+		using pointer           = _t<detail_iterator_traits::extract_pointer_member<I>>;
+		using reference         = _t<detail_iterator_traits::extract_reference_member<I>>;
+	};
+
+	struct contiguous_iterator_tag : std::random_access_iterator_tag {};
+
+	template<class T>
+	requires is_object_v<T>
+	struct iterator_traits<T*> {
+		using iterator_concept  = contiguous_iterator_tag;
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type        = remove_cv_t<T>;
+		using difference_type   = std::ptrdiff_t;
+		using pointer           = T*;
+		using reference         = T&;
+	};
+} // namespace cjdb
+
+#endif // CJDB_ITERATOR_ITERATOR_TRAITS_HPP

--- a/include/cjdb/iterator/readable_traits.hpp
+++ b/include/cjdb/iterator/readable_traits.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_ITERATOR_READABLE_TRAITS_HPP
+#define CJDB_ITERATOR_READABLE_TRAITS_HPP
+
+#include "cjdb/detail/iterator/readable_traits.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+
+namespace cjdb {
+	template<typename> struct readable_traits {};
+
+	template<typename T>
+	struct readable_traits<T*> : detail_readable_traits::cond_value_type<T> {};
+
+	template<typename I>
+	requires is_array_v<I>
+	struct readable_traits<I> {
+		using value_type = remove_cv_t<remove_extent_t<I>>;
+	};
+
+	template<typename I>
+	struct readable_traits<I const> : readable_traits<I> {};
+
+	template<detail_readable_traits::has_value_type T>
+	struct readable_traits<T> : detail_readable_traits::cond_value_type<typename T::value_type> {};
+
+	template<detail_readable_traits::has_element_type T>
+	struct readable_traits<T> : detail_readable_traits::cond_value_type<typename T::element_type> {};
+
+	template<typename T>
+	using iter_value_t = _t<detail_readable_traits::extract_readable_traits<T>>;
+} // namespace cjdb
+
+#endif // CJDB_ITERATOR_READABLE_TRAITS_HPP

--- a/include/cjdb/iterator/reference.hpp
+++ b/include/cjdb/iterator/reference.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_ITERATOR_REFERENCE_HPP
+#define CJDB_ITERATOR_REFERENCE_HPP
+
+#include "cjdb/detail/iterator/reference.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
+#include <utility>
+
+namespace cjdb {
+	template<detail_iterator_reference::dereferenceable T>
+	using iter_reference_t = decltype(*std::declval<T&>());
+} // namespace cjdb
+
+#endif // CJDB_ITERATOR_REFERENCE_HPP

--- a/include/cjdb/type_traits/is_primary.hpp
+++ b/include/cjdb/type_traits/is_primary.hpp
@@ -4,15 +4,16 @@
 #ifndef CJDB_TYPE_TRATIS_IS_PRIMARY_HPP
 #define CJDB_TYPE_TRATIS_IS_PRIMARY_HPP
 
-#include "cjdb/concepts/core/same_as.hpp"
+#include "cjdb/concepts/core/derived_from.hpp"
+#include "cjdb/detail/type_traits/primary_template.hpp"
+#include "cjdb/type_traits/type_traits.hpp"
 #include <utility>
 
 namespace cjdb {
-	template<class T>
-	concept is_primary = requires {
-		typename T::detail_primary;
-		requires same_as<typename T::detail_primary, T>;
-	};
+	template<typename T>
+	inline constexpr auto is_primary =
+		is_base_of_v<detail_primary_template::primary_template, T> and
+		not derived_from<T, detail_primary_template::primary_template>;
 } // namespace cjdb
 
 #endif // CJDB_TYPE_TRATIS_IS_PRIMARY_HPP

--- a/test/include/cjdb/test/iterator/legacy_iterator_wrapper.hpp
+++ b/test/include/cjdb/test/iterator/legacy_iterator_wrapper.hpp
@@ -1,0 +1,277 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef CJDB_TEST_ITERATOR_LEGACY_ITERATOR_WRAPPER_HPP
+#define CJDB_TEST_ITERATOR_LEGACY_ITERATOR_WRAPPER_HPP
+
+#include "cjdb/detail/iterator/legacy_iterator.hpp"
+
+namespace cjdb_test {
+	template<typename I>
+	inline constexpr auto has_arrow = requires(I& i) {
+		i.operator->();
+	};
+
+	/// \brief Extension point for `legacy_iterator_wrapper` to support `operator->`.
+	///
+	template<typename I>
+	struct arrow_extension {};
+
+	/// \brief Wrapper around a legacy C++ iterator to give it a minimal interface.
+	/// \tparam I       Legacy C++ iterator type.
+	/// \tparam Args... A series of templates that allow for extensions to `legacy_iterator`. For
+	///                 example, legacy input iterators require `value_type` and `difference_type` as
+	///                 members; legacy iterators do not (to support them in `legacy_iterator` would
+	///                 break minimal interface goal).
+	///                 Adding support for a these members is done by creating passing class
+	///                 templates that can be instantiated with `I` as the only parameter: the types
+	///                 are then available for use.
+	///
+	template<cjdb::detail_legacy_iterator::legacy_iterator I, template<typename> typename... Args>
+	class legacy_iterator : public Args<I>... {
+	public:
+		constexpr explicit legacy_iterator(I i)
+		: base_{std::move(i)}
+		{}
+
+		constexpr decltype(auto) operator*() const { return *base_; }
+
+		constexpr decltype(auto) operator->() const
+		requires cjdb::derived_from<legacy_iterator, arrow_extension<I>> and has_arrow<I>
+		{ return this->base().operator->(); }
+
+		constexpr legacy_iterator& operator++()
+		{
+			++base_;
+			return *this;
+		}
+
+		constexpr legacy_iterator operator++(int)
+		{
+			auto temp = *this;
+			++*this;
+			return temp;
+		}
+	protected:
+		[[nodiscard]] constexpr I& base() { return base_; }
+		[[nodiscard]] constexpr I const& base() const { return base_; }
+	private:
+		I base_;
+	};
+
+	/// \brief Wrapper around a legacy C++ input iterator to give it a minimal interface.
+	/// \tparam I       Legacy C++ input iterator type.
+	/// \tparam Args... A series of templates that allow for extensions to `legacy_iterator`. For
+	///                 example, legacy input iterators require `value_type` and `difference_type` as
+	///                 members; legacy iterators do not (to support them in `legacy_iterator` would
+	///                 break minimal interface goal).
+	///                 Adding support for a these members is done by creating passing class
+	///                 templates that can be instantiated with `I` as the only parameter: the types
+	///                 are then available for use.
+	///
+	template<cjdb::detail_legacy_iterator::legacy_input_iterator I, template<typename> typename... Args>
+	class legacy_input_iterator : public legacy_iterator<I, Args...> {
+	public:
+		using legacy_iterator<I, Args...>::legacy_iterator;
+
+		static_assert((requires { typename Args<I>::value_type; } or ...));
+		static_assert((requires { typename Args<I>::difference_type; } or ...));
+
+		constexpr bool operator==(legacy_input_iterator const& other) const
+		{ return this->base() == other.base(); }
+
+		constexpr bool operator!=(legacy_input_iterator const& other) const
+		{ return not (*this == other); }
+
+		constexpr legacy_input_iterator& operator++()
+		{
+			++static_cast<legacy_iterator<I, Args...>&>(*this);
+			return *this;
+		}
+
+		constexpr legacy_input_iterator operator++(int)
+		{
+			return legacy_input_iterator{static_cast<legacy_iterator<I, Args...>&>(*this)};
+		}
+	};
+
+	/// \brief Wrapper around a legacy C++ forward iterator to give it a minimal interface.
+	/// \tparam I       Legacy C++ forward iterator type.
+	/// \tparam Args... A series of templates that allow for extensions to `legacy_iterator`. For
+	///                 example, legacy input iterators require `value_type` and `difference_type` as
+	///                 members; legacy iterators do not (to support them in `legacy_iterator` would
+	///                 break minimal interface goal).
+	///                 Adding support for a these members is done by creating passing class
+	///                 templates that can be instantiated with `I` as the only parameter: the types
+	///                 are then available for use.
+	///
+	template<cjdb::detail_legacy_iterator::legacy_forward_iterator I,
+	         template<typename> typename... Args>
+	class legacy_forward_iterator : public legacy_input_iterator<I, Args...> {
+	public:
+		constexpr legacy_forward_iterator()
+		: legacy_input_iterator<I, Args...>{I{}}
+		{}
+
+		constexpr legacy_forward_iterator& operator++()
+		{
+			++static_cast<legacy_iterator<I, Args...>&>(*this);
+			return *this;
+		}
+
+		constexpr legacy_forward_iterator operator++(int)
+		{
+			return legacy_forward_iterator{static_cast<legacy_iterator<I, Args...>&>(*this)};
+		}
+	};
+
+	/// \brief Wrapper around a legacy C++ bidirectional iterator to give it a minimal interface.
+	/// \tparam I       Legacy C++ bidirectional iterator type.
+	/// \tparam Args... A series of templates that allow for extensions to `legacy_iterator`. For
+	///                 example, legacy input iterators require `value_type` and `difference_type` as
+	///                 members; legacy iterators do not (to support them in `legacy_iterator` would
+	///                 break minimal interface goal).
+	///                 Adding support for a these members is done by creating passing class
+	///                 templates that can be instantiated with `I` as the only parameter: the types
+	///                 are then available for use.
+	///
+	template<cjdb::detail_legacy_iterator::legacy_bidirectional_iterator I,
+	         template<typename> typename... Args>
+	class legacy_bidirectional_iterator : public legacy_forward_iterator<I, Args...> {
+	public:
+		using legacy_forward_iterator<I, Args...>::legacy_forward_iterator;
+
+		constexpr legacy_bidirectional_iterator& operator++()
+		{
+			++static_cast<legacy_iterator<I, Args...>&>(*this);
+			return *this;
+		}
+
+		constexpr legacy_bidirectional_iterator operator++(int)
+		{
+			return legacy_input_iterator{static_cast<legacy_iterator<I, Args...>&>(*this)};
+		}
+
+		constexpr legacy_bidirectional_iterator& operator--()
+		{
+			--this->base();
+			return *this;
+		}
+
+		constexpr legacy_bidirectional_iterator operator--(int)
+		{
+			auto temp = *this;
+			--*this;
+			return temp;
+		}
+	};
+
+	/// \brief Wrapper around a legacy C++ random-access iterator to give it a minimal interface.
+	/// \tparam I       Legacy C++ random-access iterator type.
+	/// \tparam Args... A series of templates that allow for extensions to `legacy_iterator`. For
+	///                 example, legacy input iterators require `value_type` and `difference_type` as
+	///                 members; legacy iterators do not (to support them in `legacy_iterator` would
+	///                 break minimal interface goal).
+	///                 Adding support for a these members is done by creating passing class
+	///                 templates that can be instantiated with `I` as the only parameter: the types
+	///                 are then available for use.
+	///
+	template<cjdb::detail_legacy_iterator::legacy_random_access_iterator I,
+	         template<typename> typename... Args>
+	class legacy_random_access_iterator : public legacy_bidirectional_iterator<I, Args...> {
+	public:
+		using legacy_bidirectional_iterator<I, Args...>::legacy_bidirectional_iterator;
+		using typename legacy_bidirectional_iterator<I, Args...>::difference_type;
+
+		constexpr legacy_random_access_iterator& operator++()
+		{
+			++static_cast<legacy_iterator<I, Args...>&>(*this);
+			return *this;
+		}
+
+		constexpr legacy_random_access_iterator operator++(int)
+		{
+			return legacy_input_iterator{static_cast<legacy_iterator<I, Args...>&>(*this)};
+		}
+
+			constexpr legacy_random_access_iterator& operator--()
+		{
+			++static_cast<legacy_iterator<I, Args...>&>(*this);
+			return *this;
+		}
+
+		constexpr legacy_random_access_iterator operator--(int)
+		{
+			return legacy_input_iterator{static_cast<legacy_iterator<I, Args...>&>(*this)};
+		}
+
+		constexpr legacy_random_access_iterator& operator+=(difference_type const n)
+		{
+			this->base() += n;
+			return *this;
+		}
+
+		constexpr legacy_random_access_iterator& operator-=(difference_type const n)
+		{ return *this += -n; }
+
+		friend constexpr legacy_random_access_iterator
+		operator+(legacy_random_access_iterator x, difference_type const y)
+		{ return x += y; }
+
+		friend constexpr legacy_random_access_iterator
+		operator+(difference_type const y, legacy_random_access_iterator x)
+		{ return x + y; }
+
+		friend constexpr legacy_random_access_iterator
+		operator-(legacy_random_access_iterator x, difference_type const y)
+		{ return x -= y; }
+
+		constexpr difference_type operator-(legacy_random_access_iterator const& other) const
+		{ return this->base() - other.base(); }
+
+		constexpr decltype(auto) operator[](difference_type const n) const
+		{ return *(*this + n); }
+
+		constexpr bool operator<(legacy_random_access_iterator const& other) const
+		{ return this->base() < other.base(); }
+
+		constexpr bool operator>(legacy_random_access_iterator const& other) const
+		{ return other < *this; }
+
+		constexpr bool operator<=(legacy_random_access_iterator const& other) const
+		{ return not (other < *this); }
+
+		constexpr bool operator>=(legacy_random_access_iterator const& other) const
+		{ return not (*this < other); }
+	};
+
+	/// \brief Minimum extension point for `legacy_input_iterator`.
+	///
+	template<typename I>
+	struct minimal_extension {
+		using difference_type = typename cjdb::incrementable_traits<I>::difference_type;
+		using value_type = typename cjdb::readable_traits<I>::value_type;
+	};
+
+	/// \brief Extension point for reference member.
+	///
+	template<typename I>
+	struct reference_extension {
+		using reference = typename I::reference;
+	};
+
+	/// \brief Extension point for pointer member.
+	///
+	template<typename I>
+	struct pointer_extension {
+		using pointer = typename I::pointer;
+	};
+
+	/// \brief Extension point to indicate no extension points.
+	/// \note This is used for function overloading when there isn't a better name for two overloads.
+	///
+	template<typename I>
+	struct empty_extension {};
+} // namespace cjdb_test
+
+#endif // CJDB_TEST_ITERATOR_LEGACY_ITERATOR_WRAPPER_HPP

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -3,4 +3,5 @@
 #
 add_subdirectory(concepts)
 add_subdirectory(functional)
+add_subdirectory(iterator)
 add_subdirectory(type_traits)

--- a/test/unit/iterator/CMakeLists.txt
+++ b/test/unit/iterator/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) Christopher Di Bella.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+add_cjdblib_test(FILENAME incrementable_traits.cpp)
+add_cjdblib_test(FILENAME readable_traits.cpp)
+add_cjdblib_test(FILENAME legacy_iterator.cpp)
+add_cjdblib_test(FILENAME iterator_traits.cpp INCLUDE "${CMAKE_SOURCE_DIR}/test/include")

--- a/test/unit/iterator/incrementable_traits.cpp
+++ b/test/unit/iterator/incrementable_traits.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#include "cjdb/iterator/incrementable_traits.hpp"
+
+#include "cjdb/concepts/core/same_as.hpp"
+#include "cjdb/concepts/core/integral.hpp"
+#include <iterator>
+#include <vector>
+
+template<typename T, typename Expected>
+constexpr void instantiate_incrementable_traits()
+{
+	static_assert(cjdb::same_as<typename cjdb::incrementable_traits<T>::difference_type, Expected>);
+	static_assert(cjdb::same_as<cjdb::iter_difference_t<T>, Expected>);
+}
+
+template<typename T>
+constexpr void check_pointer()
+{
+	instantiate_incrementable_traits<T*, std::ptrdiff_t>();
+	instantiate_incrementable_traits<T const*, std::ptrdiff_t>();
+
+	instantiate_incrementable_traits<T[], std::ptrdiff_t>(); // NOLINT(modernize-avoid-c-arrays)
+}
+
+template<typename T>
+constexpr void check_with_difference_type()
+{
+	struct diff { using difference_type = T; };
+	instantiate_incrementable_traits<diff, T>();
+	instantiate_incrementable_traits<diff const, T>();
+}
+
+template<typename T>
+struct friend_minus {
+	friend T operator-(friend_minus, friend_minus) { return T(); }
+};
+
+template<cjdb::integral D>
+constexpr void check_minus()
+{
+	struct member {
+		D operator-(member) const { return D{}; }
+	};
+	instantiate_incrementable_traits<member, std::make_signed_t<D>>();
+	instantiate_incrementable_traits<member const, std::make_signed_t<D>>();
+	instantiate_incrementable_traits<friend_minus<D>, std::make_signed_t<D>>();
+	instantiate_incrementable_traits<friend_minus<D> const, std::make_signed_t<D>>();
+}
+
+template<typename T>
+constexpr void check_minus()
+{
+	constexpr auto result = requires {
+		typename cjdb::incrementable_traits<friend_minus<T>>::difference_type;
+	};
+	static_assert(not result, "cjdb::iter_difference_t<bad_minus<T>> should fail.");
+}
+
+template<typename D, typename Minus>
+struct difference_minus {
+	using difference_type = D;
+	constexpr friend Minus operator-(difference_minus, difference_minus)
+	{ return Minus(); }
+};
+
+template<typename D, cjdb::integral Minus>
+requires (not cjdb::same_as<D, Minus>)
+constexpr void check_with_both()
+{
+	struct member {
+		using difference_type = D;
+		Minus operator-(member const&) const;
+	};
+	instantiate_incrementable_traits<member, D>();
+	instantiate_incrementable_traits<member const, D>();
+	instantiate_incrementable_traits<difference_minus<D, Minus>, D>();
+	instantiate_incrementable_traits<difference_minus<D, Minus> const, D>();
+}
+
+int main()
+{
+	struct dummy {};
+
+	check_pointer<int>();
+	check_pointer<double>();
+	check_pointer<int*>();
+	check_pointer<dummy>();
+
+	check_with_difference_type<int>();
+	check_with_difference_type<long>();
+	check_with_difference_type<float>();
+	check_with_difference_type<dummy>();
+	check_with_difference_type<int&>();
+	check_with_difference_type<int const&>();
+	check_with_difference_type<int volatile&>();
+	check_with_difference_type<int*>();
+	check_with_difference_type<int* const>();
+	check_with_difference_type<int* volatile>();
+	check_with_difference_type<int(*)()>();
+	check_with_difference_type<int(&)()>();
+
+	{
+		// succeeds
+		check_minus<char>();
+		check_minus<signed char>();
+		check_minus<unsigned char>();
+		check_minus<short>();
+		check_minus<unsigned short>();
+		check_minus<int>();
+		check_minus<unsigned int>();
+		check_minus<long>();
+		check_minus<unsigned long>();
+		check_minus<long long>();
+		check_minus<unsigned long long>();
+
+		// fails
+		check_minus<void>();
+		check_minus<double>();
+		check_minus<dummy>();
+		check_minus<int&>();
+		check_minus<int const&>();
+		check_minus<int volatile&>();
+		check_minus<int*>();
+		check_minus<int* const>();
+		check_minus<int* volatile>();
+		check_minus<int(*)()>();
+		check_minus<int(&)()>();
+	}
+
+	check_with_both<int, long>();
+	check_with_both<double, int>();
+	check_with_both<dummy, char>();
+	check_with_both<int&, char>();
+	check_with_both<int const&, char>();
+	check_with_both<int volatile&, char>();
+	check_with_both<int*, char>();
+	check_with_both<int* const, char>();
+	check_with_both<int* volatile, char>();
+	check_with_both<int(*)(), char>();
+	check_with_both<int(&)(), char>();
+
+	// now for some standard types
+	using cjdb::same_as, cjdb::iter_difference_t;
+	static_assert(same_as<iter_difference_t<std::reverse_iterator<int*>>, std::ptrdiff_t>);
+	static_assert(same_as<iter_difference_t<std::vector<int>>, std::vector<int>::difference_type>);
+}

--- a/test/unit/iterator/iterator_traits.cpp
+++ b/test/unit/iterator/iterator_traits.cpp
@@ -1,0 +1,260 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#include "cjdb/iterator/iterator_traits.hpp"
+
+#include "cjdb/concepts/core/integral.hpp"
+#include "cjdb/iterator/incrementable_traits.hpp"
+#include "cjdb/iterator/readable_traits.hpp"
+#include "cjdb/test/iterator/legacy_iterator_wrapper.hpp"
+#include <vector>
+
+template<typename Category, typename Value, typename Difference, typename Reference>
+struct explicit_members {
+	using iterator_category = Category;
+	using value_type = Value;
+	using difference_type = Difference;
+	using reference = Reference;
+};
+
+template<typename Category, typename Value, typename Difference, typename Reference>
+struct explicit_members_with_pointer : explicit_members<Category, Value, Difference, Reference> {
+	using pointer = typename explicit_members<Category, Value, Difference, Reference>::value_type*;
+};
+
+template<typename Category, typename Value, typename Difference, typename Reference>
+constexpr void check_members_explicitly_provided()
+{
+	{
+		using fake_iterator = explicit_members<Category, Value, Difference, Reference>;
+		using iterator_traits = cjdb::iterator_traits<fake_iterator>;
+		static_assert(cjdb::same_as<typename iterator_traits::iterator_category, Category>);
+		static_assert(cjdb::same_as<typename iterator_traits::value_type, Value>);
+		static_assert(cjdb::same_as<typename iterator_traits::difference_type, Difference>);
+		static_assert(cjdb::same_as<typename iterator_traits::reference, Reference>);
+		static_assert(cjdb::same_as<typename iterator_traits::pointer, void>);
+	}
+
+	{
+		using fake_iterator = explicit_members_with_pointer<Category, Value, Difference, Reference>;
+		using iterator_traits = cjdb::iterator_traits<fake_iterator>;
+		static_assert(cjdb::same_as<typename iterator_traits::iterator_category, Category>);
+		static_assert(cjdb::same_as<typename iterator_traits::value_type, Value>);
+		static_assert(cjdb::same_as<typename iterator_traits::difference_type, Difference>);
+		static_assert(cjdb::same_as<typename iterator_traits::reference, Reference>);
+		static_assert(cjdb::same_as<typename iterator_traits::pointer, Value*>);
+	}
+}
+
+template<typename I, template<typename> typename... Args>
+requires (sizeof...(Args) > 0)
+constexpr void check_with_legacy_input_iterator()
+{
+	auto check = []<typename Iterator, typename Traits>(Iterator, Traits, auto category) {
+		static_assert(cjdb::same_as<typename Traits::iterator_category, decltype(category)>);
+		static_assert(cjdb::same_as<typename Traits::value_type, cjdb::iter_value_t<I>>);
+		static_assert(cjdb::same_as<typename Traits::difference_type, cjdb::iter_difference_t<I>>);
+
+		if constexpr (cjdb::derived_from<Iterator, cjdb_test::reference_extension<I>>) {
+			static_assert(cjdb::same_as<typename Traits::reference, typename Iterator::reference>);
+		}
+		else {
+			static_assert(cjdb::same_as<typename Traits::reference, cjdb::iter_reference_t<I>>);
+		}
+
+		if constexpr (cjdb::derived_from<Iterator, cjdb_test::pointer_extension<I>>) { // NOLINT(bugprone-branch-clone)
+			static_assert(cjdb::same_as<typename Traits::pointer, typename Iterator::pointer>);
+		}
+		else if constexpr (cjdb_test::has_arrow<Iterator>) { // NOLINT(bugprone-branch-clone)
+			static_assert(cjdb::same_as<typename Traits::pointer,
+			                            decltype(std::declval<I&>().operator->())>);
+		}
+		else {
+			static_assert(cjdb::same_as<typename Traits::pointer, void>);
+		}
+	};
+
+	using cjdb_test::minimal_extension;
+	{
+		using iterator = cjdb_test::legacy_input_iterator<I, minimal_extension, Args...>;
+		using iterator_traits = cjdb::iterator_traits<iterator>;
+		check(iterator{I{}}, iterator_traits{}, std::input_iterator_tag{});
+	}
+	{
+		using iterator = cjdb_test::legacy_forward_iterator<I, minimal_extension, Args...>;
+		using iterator_traits = cjdb::iterator_traits<iterator>;
+		check(iterator{}, iterator_traits{}, std::forward_iterator_tag{});
+	}
+	{
+		using iterator = cjdb_test::legacy_bidirectional_iterator<I, minimal_extension, Args...>;
+		using iterator_traits = cjdb::iterator_traits<iterator>;
+		check(iterator{}, iterator_traits{}, std::bidirectional_iterator_tag{});
+	}
+	{
+		using iterator = cjdb_test::legacy_random_access_iterator<I, minimal_extension, Args...>;
+		using iterator_traits = cjdb::iterator_traits<iterator>;
+		check(iterator{}, iterator_traits{}, std::random_access_iterator_tag{});
+	}
+}
+
+template<typename I>
+constexpr void check_with_legacy_input_iterator()
+{
+	using cjdb_test::empty_extension, cjdb_test::reference_extension;
+	using cjdb_test::pointer_extension, cjdb_test::arrow_extension;
+	check_with_legacy_input_iterator<I, empty_extension>();
+	check_with_legacy_input_iterator<I, reference_extension>();
+	check_with_legacy_input_iterator<I, pointer_extension>();
+	check_with_legacy_input_iterator<I, arrow_extension>();
+	check_with_legacy_input_iterator<I, reference_extension, pointer_extension>();
+	check_with_legacy_input_iterator<I, reference_extension, arrow_extension>();
+}
+
+template<typename I>
+constexpr void check_with_legacy_iterator()
+{
+	{
+		using iterator = cjdb_test::legacy_iterator<I>;
+		using iterator_traits = cjdb::iterator_traits<iterator>;
+		static_assert(cjdb::same_as<typename iterator_traits::iterator_category,
+		                            std::output_iterator_tag>);
+		static_assert(cjdb::same_as<typename iterator_traits::value_type, void>);
+		static_assert(cjdb::same_as<typename iterator_traits::difference_type, void>);
+		static_assert(cjdb::same_as<typename iterator_traits::reference, void>);
+		static_assert(cjdb::same_as<typename iterator_traits::pointer, void>);
+	}
+	{
+		using iterator = cjdb_test::legacy_iterator<I, cjdb::incrementable_traits>;
+		using iterator_traits = cjdb::iterator_traits<iterator>;
+		static_assert(cjdb::same_as<typename iterator_traits::iterator_category,
+		                            std::output_iterator_tag>);
+		static_assert(cjdb::same_as<typename iterator_traits::value_type, void>);
+		static_assert(cjdb::same_as<typename iterator_traits::difference_type,
+		                            typename cjdb::iter_difference_t<I>>);
+		static_assert(cjdb::same_as<typename iterator_traits::reference, void>);
+		static_assert(cjdb::same_as<typename iterator_traits::pointer, void>);
+	}
+}
+
+template<typename T, typename Expected = T>
+constexpr void check_pointer()
+{
+	using iterator_traits = cjdb::iterator_traits<T*>;
+	static_assert(cjdb::same_as<typename iterator_traits::iterator_concept,
+	                            cjdb::contiguous_iterator_tag>);
+	static_assert(cjdb::same_as<typename iterator_traits::iterator_category,
+	                            std::random_access_iterator_tag>);
+	static_assert(cjdb::same_as<typename iterator_traits::value_type, Expected>);
+	static_assert(cjdb::same_as<typename iterator_traits::difference_type, std::ptrdiff_t>);
+	static_assert(cjdb::same_as<typename iterator_traits::pointer, T*>);
+	static_assert(cjdb::same_as<typename iterator_traits::reference, T&>);
+}
+
+template<typename T>
+constexpr void check_fails()
+{
+	{
+		constexpr auto result = requires { typename cjdb::iterator_traits<T>::iterator_concept; };
+		static_assert(not result, "iterator_traits<T>::iterator_concept should not exist.");
+	}
+	{
+		constexpr auto result = requires { typename cjdb::iterator_traits<T>::iterator_category; };
+		static_assert(not result, "iterator_traits<T>::iterator_category should not exist.");
+	}
+	{
+		constexpr auto result = requires { typename cjdb::iterator_traits<T>::value_type; };
+		static_assert(not result, "iterator_traits<T>::value_type should not exist.");
+	}
+	{
+		constexpr auto result = requires { typename cjdb::iterator_traits<T>::difference_type; };
+		static_assert(not result, "iterator_traits<T>::difference_type should not exist.");
+	}
+	{
+		constexpr auto result = requires { typename cjdb::iterator_traits<T>::pointer; };
+		static_assert(not result, "iterator_traits<T>::pointer should not exist.");
+	}
+	{
+		constexpr auto result = requires { typename cjdb::iterator_traits<T>::reference; };
+		static_assert(not result, "iterator_traits<T>::reference should not exist.");
+	}
+}
+
+struct missing_iterator_category {
+	using value_type = int;
+	using difference_type = int;
+	using pointer = int*;
+	using reference = int&;
+};
+
+struct missing_value_type {
+	using iterator_category = std::input_iterator_tag;
+	using difference_type = int;
+	using pointer = int*;
+	using reference = int&;
+};
+
+struct missing_difference_type {
+	using iterator_category = std::input_iterator_tag;
+	using value_type = int;
+	using pointer = int*;
+	using reference = int&;
+};
+
+struct missing_reference {
+	using iterator_category = std::input_iterator_tag;
+	using value_type = int;
+	using difference_type = int;
+	using pointer = int&;
+};
+
+int main()
+{
+	check_members_explicitly_provided<std::input_iterator_tag, int, int, int&>();
+	check_members_explicitly_provided<std::input_iterator_tag, int, long, int&>();
+	check_members_explicitly_provided<std::forward_iterator_tag, int, double, int&>();
+
+	struct dummy {};
+	check_members_explicitly_provided<std::bidirectional_iterator_tag, dummy, int, long long>();
+	check_members_explicitly_provided<std::random_access_iterator_tag, dummy, int, long long>();
+
+	check_with_legacy_input_iterator<std::vector<int>::iterator>();
+	check_with_legacy_input_iterator<std::vector<int>::const_iterator>();
+	check_with_legacy_input_iterator<std::vector<int const>::iterator>();
+	check_with_legacy_input_iterator<std::vector<int const>::const_iterator>();
+
+	check_with_legacy_iterator<std::vector<int>::iterator>();
+	check_with_legacy_iterator<std::vector<int>::const_iterator>();
+	check_with_legacy_iterator<std::vector<int const>::iterator>();
+	check_with_legacy_iterator<std::vector<int const>::const_iterator>();
+	check_with_legacy_iterator<int* volatile>();
+	check_with_legacy_iterator<dummy* volatile>();
+
+	check_pointer<int>();
+	check_pointer<int const, int>();
+	check_pointer<double>();
+	check_pointer<double volatile, double>();
+	check_pointer<dummy>();
+	check_pointer<dummy const volatile, dummy>();
+
+
+	check_fails<void>();
+	check_fails<dummy>();
+	check_fails<dummy&>();
+	check_fails<dummy* const>();
+	check_fails<dummy* const volatile>();
+	check_fails<dummy const&>();
+	check_fails<dummy volatile&>();
+	check_fails<dummy const volatile&>();
+	check_fails<dummy(*)()>();
+	check_fails<dummy(&)()>();
+	check_fails<int[]>();                    // NOLINT(modernize-avoid-c-arrays)
+	check_fails<int const[]>();              // NOLINT(modernize-avoid-c-arrays)
+	check_fails<double[]>();                 // NOLINT(modernize-avoid-c-arrays)
+	check_fails<double volatile[]>();        // NOLINT(modernize-avoid-c-arrays)
+	check_fails<dummy[]>();                  // NOLINT(modernize-avoid-c-arrays)
+	check_fails<dummy const volatile[]>();   // NOLINT(modernize-avoid-c-arrays)
+	check_fails<missing_iterator_category>();
+	check_fails<missing_value_type>();
+	check_fails<missing_difference_type>();
+	check_fails<missing_reference>();
+}

--- a/test/unit/iterator/legacy_iterator.cpp
+++ b/test/unit/iterator/legacy_iterator.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#include "cjdb/detail/iterator/legacy_iterator.hpp"
+
+#include "cjdb/iterator/incrementable_traits.hpp"
+#include "cjdb/iterator/readable_traits.hpp"
+
+#include <array>
+#include <deque>
+#include <forward_list>
+#include <iterator>
+#include <list>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+template<typename T>
+void check_legacy_iterator()
+{
+	using cjdb::detail_legacy_iterator::legacy_iterator;
+	static_assert(legacy_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_input_iterator;
+	static_assert(not legacy_input_iterator<T>);
+}
+
+template<typename T>
+void check_legacy_input_iterator()
+{
+	using cjdb::detail_legacy_iterator::legacy_iterator;
+	static_assert(legacy_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_input_iterator;
+	static_assert(legacy_input_iterator<T>);
+}
+
+template<typename T>
+void check_legacy_forward_iterator()
+{
+	using cjdb::detail_legacy_iterator::legacy_iterator;
+	static_assert(legacy_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_input_iterator;
+	static_assert(legacy_input_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_forward_iterator;
+	static_assert(legacy_forward_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_bidirectional_iterator;
+	static_assert(not legacy_bidirectional_iterator<T>);
+}
+
+template<typename T>
+void check_legacy_bidirectional_iterator()
+{
+	using cjdb::detail_legacy_iterator::legacy_iterator;
+	static_assert(legacy_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_input_iterator;
+	static_assert(legacy_input_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_forward_iterator;
+	static_assert(legacy_forward_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_bidirectional_iterator;
+	static_assert(legacy_bidirectional_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_random_access_iterator;
+	static_assert(not legacy_random_access_iterator<T>);
+}
+
+template<typename T>
+void check_legacy_random_access_iterator()
+{
+	using cjdb::detail_legacy_iterator::legacy_iterator;
+	static_assert(legacy_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_input_iterator;
+	static_assert(legacy_input_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_forward_iterator;
+	static_assert(legacy_forward_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_bidirectional_iterator;
+	static_assert(legacy_bidirectional_iterator<T>);
+
+	using cjdb::detail_legacy_iterator::legacy_random_access_iterator;
+	static_assert(legacy_random_access_iterator<T>);
+}
+
+int main()
+{
+	check_legacy_iterator<std::ostream_iterator<int>>();
+	check_legacy_iterator<std::ostream_iterator<double>>();
+	check_legacy_iterator<std::back_insert_iterator<std::vector<long>>>();
+	check_legacy_iterator<std::back_insert_iterator<std::list<std::vector<int>>>>();
+	check_legacy_iterator<std::front_insert_iterator<std::deque<long>>>();
+	check_legacy_iterator<std::front_insert_iterator<std::list<std::vector<int>>>>();
+
+	check_legacy_input_iterator<std::istream_iterator<int>>();
+	check_legacy_input_iterator<std::istream_iterator<long>>();
+
+	check_legacy_forward_iterator<std::forward_list<std::vector<std::map<int, int>>>::iterator>();
+	check_legacy_forward_iterator<std::forward_list<std::vector<std::map<int, int>>>::const_iterator>();
+	check_legacy_forward_iterator<std::unordered_set<int>::iterator>();
+	check_legacy_forward_iterator<std::unordered_set<int>::const_iterator>();
+	check_legacy_forward_iterator<std::unordered_multiset<int>::iterator>();
+	check_legacy_forward_iterator<std::unordered_multiset<int>::const_iterator>();
+	check_legacy_forward_iterator<std::unordered_map<double, int>::iterator>();
+	check_legacy_forward_iterator<std::unordered_map<double, int>::const_iterator>();
+	check_legacy_forward_iterator<std::unordered_multimap<double, long long>::iterator>();
+	check_legacy_forward_iterator<std::unordered_multimap<double, long long>::const_iterator>();
+
+	check_legacy_bidirectional_iterator<std::list<int>::iterator>();
+	check_legacy_bidirectional_iterator<std::list<int>::const_iterator>();
+	check_legacy_bidirectional_iterator<std::list<int>::reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::list<int>::const_reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::set<double>::iterator>();
+	check_legacy_bidirectional_iterator<std::set<double>::const_iterator>();
+	check_legacy_bidirectional_iterator<std::set<double>::reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::set<double>::const_reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::multiset<char>::iterator>();
+	check_legacy_bidirectional_iterator<std::multiset<char>::const_iterator>();
+	check_legacy_bidirectional_iterator<std::multiset<char>::reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::multiset<char>::const_reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::map<int, double>::iterator>();
+	check_legacy_bidirectional_iterator<std::map<int, double>::const_iterator>();
+	check_legacy_bidirectional_iterator<std::map<int, double>::reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::map<int, double>::const_reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::multimap<char, signed char>::iterator>();
+	check_legacy_bidirectional_iterator<std::multimap<char, signed char>::const_iterator>();
+	check_legacy_bidirectional_iterator<std::multimap<char, signed char>::reverse_iterator>();
+	check_legacy_bidirectional_iterator<std::multimap<char, signed char>::const_reverse_iterator>();
+
+	check_legacy_random_access_iterator<std::vector<int>::iterator>();
+	check_legacy_random_access_iterator<std::vector<int>::const_iterator>();
+	check_legacy_random_access_iterator<std::vector<int>::reverse_iterator>();
+	check_legacy_random_access_iterator<std::vector<int>::const_reverse_iterator>();
+	check_legacy_random_access_iterator<std::array<short, 1>::iterator>();
+	check_legacy_random_access_iterator<std::array<short, 1>::const_iterator>();
+	check_legacy_random_access_iterator<std::array<short, 1>::reverse_iterator>();
+	check_legacy_random_access_iterator<std::array<short, 1>::const_reverse_iterator>();
+
+	struct dummy {};
+	constexpr auto arbitrary_size = 23;
+	check_legacy_random_access_iterator<std::array<dummy, arbitrary_size>::iterator>();
+	check_legacy_random_access_iterator<std::array<dummy, arbitrary_size>::const_iterator>();
+	check_legacy_random_access_iterator<std::array<dummy, arbitrary_size>::reverse_iterator>();
+	check_legacy_random_access_iterator<std::array<dummy, arbitrary_size>::const_reverse_iterator>();
+
+	check_legacy_random_access_iterator<std::deque<int>::iterator>();
+	check_legacy_random_access_iterator<std::deque<int>::const_iterator>();
+	check_legacy_random_access_iterator<std::deque<int>::reverse_iterator>();
+	check_legacy_random_access_iterator<std::deque<int>::const_reverse_iterator>();
+}

--- a/test/unit/iterator/readable_traits.cpp
+++ b/test/unit/iterator/readable_traits.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) Christopher Di Bella.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#include "cjdb/iterator/readable_traits.hpp"
+
+#include "cjdb/concepts/core/same_as.hpp"
+#include "cjdb/concepts/core/integral.hpp"
+#include <vector>
+
+template<typename T, typename Expected>
+constexpr void instantiate_readable_traits()
+{
+	using cjdb::same_as, cjdb::readable_traits, cjdb::iter_value_t;
+	static_assert(same_as<typename readable_traits<T>::value_type, Expected>);
+	static_assert(same_as<iter_value_t<T>, typename readable_traits<T>::value_type>);
+}
+
+template<typename T>
+constexpr void check_array()
+{
+	instantiate_readable_traits<T[], T>();                // NOLINT(modernize-avoid-c-arrays)
+	instantiate_readable_traits<T const[], T>();          // NOLINT(modernize-avoid-c-arrays)
+	instantiate_readable_traits<T volatile[], T>();       // NOLINT(modernize-avoid-c-arrays)
+	instantiate_readable_traits<T const volatile[], T>(); // NOLINT(modernize-avoid-c-arrays)
+}
+
+template<typename T, typename Expected>
+constexpr void check_explicit_member()
+{
+	instantiate_readable_traits<T, Expected>();
+	instantiate_readable_traits<T const, Expected>();
+}
+
+template<typename T>
+constexpr void check_fails()
+{
+	constexpr auto result = requires { typename cjdb::readable_traits<T>::value_type; };
+	static_assert(not result, "This type shouldn't be readable!");
+}
+
+template<typename T>
+constexpr void check_ref()
+{
+	struct ref_value {
+		using value_type = T&;
+	};
+	check_fails<ref_value>();
+
+	struct ref_element {
+		using element_type = T&;
+	};
+	check_fails<ref_element>();
+
+	if (not (std::is_const_v<T> or std::is_volatile_v<T>)) {
+		check_ref<T const>();
+		check_ref<T volatile>();
+		check_ref<T const volatile>();
+	}
+}
+
+int main()
+{
+	check_array<int>();
+	check_array<long>();
+	check_array<double>();
+
+	struct dummy {};
+	check_array<dummy>();
+
+	struct has_value_type {
+		using value_type = int;
+	};
+	check_explicit_member<has_value_type, int>();
+	check_explicit_member<std::vector<int>::iterator, int>();
+	check_explicit_member<std::vector<int const>::iterator, int>();
+
+	struct has_element_type {
+		using element_type = dummy;
+	};
+	check_explicit_member<has_element_type, dummy>();
+	check_explicit_member<std::shared_ptr<long>, long>();
+	check_explicit_member<std::shared_ptr<long const>, long>();
+
+	check_fails<int>();
+	check_fails<dummy>();
+
+	struct has_both : has_value_type, has_element_type {};
+	check_fails<has_both>();
+
+	struct void_value {
+		using value_type = void;
+	};
+	check_fails<void_value>();
+
+	struct void_element {
+		using element_type = void;
+	};
+	check_fails<void_element>();
+
+	check_ref<int>();
+	check_ref<dummy>();
+	check_ref<std::shared_ptr<long>>();
+}


### PR DESCRIPTION
[iterator.assoc.types] defines incrementable_traits, iter_difference_t,
readable_traits, iter_value_t, and iterator_traits. This commit provides
all of these, plus any dependent machinery.