### PR TITLE
revises the CI so it depends more on Cirrus CI infra

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@
 #
 task:
   container:
-    image: cjdb/cirrus-ci
+    dockerfile: config/ci/Dockerfile
     cpu: 8
     memory: 16G
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,8 @@ task:
     CLANG_TIDY_PATH: /usr/local/bin/clang-tidy
     matrix:
       - PROFILE: clang-libcxx
-        ENABLE_CLANG_TIDY: On
+      - PROFILE: clang-libstdcxx
+      - PROFILE: gcc
     matrix:
       - BUILD_TYPE: Debug
       - BUILD_TYPE: Release
@@ -23,8 +24,6 @@ task:
     - conan install ..
         --profile=${PROFILE}
         --settings build_type=${BUILD_TYPE}
-        --options enable_clang_tidy=${ENABLE_CLANG_TIDY}
-        --options clang_tidy_path=${CLANG_TIDY_PATH}
         --build
   conan_build_configure_script:
     - cd build-${BUILD_TYPE}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,8 +10,6 @@ task:
     CLANG_TIDY_PATH: /usr/local/bin/clang-tidy
     matrix:
       - PROFILE: clang-libcxx
-      - PROFILE: clang-libstdcxx
-      - PROFILE: gcc
     matrix:
       - BUILD_TYPE: Debug
       - BUILD_TYPE: Release

--- a/config/ci/Dockerfile
+++ b/config/ci/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Christopher Di Bella.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-FROM ubuntu:eoan
+FROM ubuntu:bionic
 
 COPY --from=cjdb/gcc-trunk /usr/local /usr/local
 COPY --from=cjdb/clang-concepts /usr/local/ /usr/local

--- a/config/ci/Dockerfile
+++ b/config/ci/Dockerfile
@@ -1,16 +1,21 @@
 # Copyright (c) Christopher Di Bella.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-FROM ubuntu:bionic
+FROM ubuntu:bionic AS python-build
 
+COPY --from=cjdb/python-3.8 /usr/local /usr/local
 COPY --from=cjdb/gcc-trunk /usr/local /usr/local
 COPY --from=cjdb/clang-concepts /usr/local/ /usr/local
 
-RUN apt-get update
-RUN apt-get dist-upgrade -y
-RUN apt-get install -y python3.7 python3-pip ninja-build binutils libz3-dev libedit-dev swig libtinfo-dev
-RUN python3 -m pip install pip --upgrade
-RUN python3 -m pip install cmake conan
+RUN apt-get update          && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y wget ninja-build binutils libz3-dev libedit-dev swig libtinfo-dev libsqlite3-dev
+
+RUN update-alternatives --install /usr/local/bin/python3 python3 /usr/local/bin/python3.8 100
+
+# RUN apt-get install -y make libssl-dev  libffi-dev zlib1g-dev libz-dev libbz2-dev
+
+RUN python3 -m pip install pip --upgrade && python3 -m pip install cmake conan
 
 ENV PATH="/usr/local/bin:$PATH" LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:/usr/local/libexec"
 RUN echo "#include <iostream>\n\
@@ -27,19 +32,16 @@ int main()\n\
 	hello(42);\n\
 }\n\
 " >/tmp/hello.cpp
-RUN cat /tmp/hello.cpp
 RUN g++ -std=c++2a /tmp/hello.cpp -o /tmp/a.out -fuse-ld=gold
 RUN clang++ -std=c++2a /tmp/hello.cpp -o /tmp/a.out -fuse-ld=lld
 RUN clang++ -std=c++2a /tmp/hello.cpp -o /tmp/a.out -stdlib=libc++ -cxx-isystem /usr/local/include/c++/v1 -fuse-ld=lld -L /usr/local/lib/ -Wl,-rpath,/usr/local/lib/ -lc++abi
 RUN cmake --version
-
 WORKDIR /tmp
 RUN conan new Hello/0.1 -t
-
 WORKDIR /tmp/Hello/build
 RUN conan install .. || true
-RUN sed -i '53s/"9.2"/"9.2", "10"/' ~/.conan/settings.yml
-RUN sed -i '69s/"8"/"8", "9", "10"/' ~/.conan/settings.yml
+RUN sed -i '53s/"9.2"/"9.2", "10"/' ~/.conan/settings.yml && \
+    sed -i '69s/"8"/"8", "9", "10"/' ~/.conan/settings.yml
 
 WORKDIR /
 RUN rm -rf /tmp/*

--- a/config/ci/Dockerfile
+++ b/config/ci/Dockerfile
@@ -3,44 +3,43 @@
 #
 FROM ubuntu:bionic
 
-RUN apt update                                                                               && \
-    apt install -y software-properties-common                                                && \
-    apt-add-repository ppa:ubuntu-toolchain-r/test                                           && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 15CF4D18AF4F7421       && \
-    apt-add-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'        && \
-    apt upgrade -y                                                                           && \
-    apt update                                                                               && \
-    apt install -y gcc-8 g++-8 clang-8 clang++-8 lld-8 ninja-build git python3 python3-pip   && \
-    python3 -m pip install pip --upgrade                                                     && \
-    python3 -m pip install cmake conan
+COPY --from=cjdb/gcc-trunk /usr/local /usr/local
+COPY --from=cjdb/clang-concepts /usr/local/ /usr/local
 
-# LLVM install
+RUN apt update
+RUN apt dist-upgrade -y
+RUN apt install -y python3 python3-pip ninja-build binutils libz3-dev libedit-dev swig
+RUN python3 -m pip install pip --upgrade
+RUN python3 -m pip install cmake conan
+
+ENV PATH="/usr/local/bin:$PATH" LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:/usr/local/libexec"
+RUN echo "#include <iostream>\n\
+\n\
+template<typename T>\n\
+requires (sizeof(T) == sizeof(int))\n\
+constexpr void hello(T t)\n\
+{\n\
+	std::cout << \"Hello, \" << t << '\\\\n';\n\
+}\n\
+\n\
+int main()\n\
+{\n\
+	hello(42);\n\
+}\n\
+" >/tmp/hello.cpp
+RUN cat /tmp/hello.cpp
+RUN g++ -std=c++2a /tmp/hello.cpp -o /tmp/a.out -fuse-ld=gold
+RUN clang++ -std=c++2a /tmp/hello.cpp -o /tmp/a.out -fuse-ld=lld
+RUN clang++ -std=c++2a /tmp/hello.cpp -o /tmp/a.out -stdlib=libc++ -cxx-isystem /usr/local/include/c++/v1 -fuse-ld=lld -L /usr/local/lib/ -Wl,-rpath,/usr/local/lib/ -lc++abi
+RUN cmake --version
+
 WORKDIR /tmp
-RUN git clone https://github.com/saarraz/clang-concepts-monorepo.git
+RUN conan new Hello/0.1 -t
 
-WORKDIR /tmp/clang-concepts-monorepo
-RUN git checkout concepts
-
-WORKDIR /tmp/build
-RUN cmake -GNinja ../clang-concepts-monorepo/llvm                                            \
-	-DCMAKE_C_COMPILER=`which clang-8`                                                        \
-	-DCMAKE_CXX_COMPILER=`which clang++-8`                                                    \
-	-DCMAKE_BUILD_TYPE=Release                                                                \
-	-DCMAKE_INSTALL_PREFIX="/opt/clang-concepts"                                              \
-	-DLLVM_INCLUDE_EXAMPLES=Off                                                               \
-	-DLLVM_INCLUDE_BENCHMARKS=Off                                                             \
-	-DLLVM_INCLUDE_TESTS=Off                                                                  \
-	-DLLVM_CXX_STD="c++14"                                                                    \
-	-DLLVM_ENABLE_WARNINGS=Off                                                                \
-	-DLLVM_ENABLE_LTO=Thin                                                                    \
-	-DLLVM_PARALLEL_LINK_JOBS=8                                                               \
-	-DLLVM_ENABLE_LLD=On                                                                      \
-	-DLLVM_TARGETS_TO_BUILD="X86"                                                             \
-	-DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;libcxx;libcxxabi;lld;polly"   \
-	-DLLVM_ENABLE_BINDINGS=Off
-RUN ninja
-RUN ninja install
+WORKDIR /tmp/Hello/build
+RUN conan install .. || true
+RUN sed -i '53s/"9.2"/"9.2", "10"/' ~/.conan/settings.yml
+RUN sed -i '69s/"8"/"8", "9", "10"/' ~/.conan/settings.yml
 
 WORKDIR /
 RUN rm -rf /tmp/*
-RUN apt remove -y clang-8 clang++-8 lld-8 && apt autoremove -y

--- a/config/ci/Dockerfile
+++ b/config/ci/Dockerfile
@@ -1,14 +1,14 @@
 # Copyright (c) Christopher Di Bella.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-FROM ubuntu:bionic
+FROM ubuntu:eoan
 
 COPY --from=cjdb/gcc-trunk /usr/local /usr/local
 COPY --from=cjdb/clang-concepts /usr/local/ /usr/local
 
-RUN apt update
-RUN apt dist-upgrade -y
-RUN apt install -y python3 python3-pip ninja-build binutils libz3-dev libedit-dev swig
+RUN apt-get update
+RUN apt-get dist-upgrade -y
+RUN apt-get install -y python3.7 python3-pip ninja-build binutils libz3-dev libedit-dev swig libtinfo-dev
 RUN python3 -m pip install pip --upgrade
 RUN python3 -m pip install cmake conan
 

--- a/config/conan/profiles/clang-libcxx
+++ b/config/conan/profiles/clang-libcxx
@@ -8,8 +8,8 @@ compiler.version=10
 compiler.libcxx=libc++
 build_type=Release
 [options]
-enable_clang_tidy=On
-clang_tidy_path=/usr/local/bin/clang-tidy
+ranges:enable_clang_tidy=On
+ranges:clang_tidy_path=/usr/local/bin/clang-tidy
 [build_requires]
 [env]
 CC=/usr/local/bin/clang

--- a/config/conan/profiles/clang-libcxx
+++ b/config/conan/profiles/clang-libcxx
@@ -8,6 +8,8 @@ compiler.version=10
 compiler.libcxx=libc++
 build_type=Release
 [options]
+enable_clang_tidy=On
+clang_tidy_path=/usr/local/bin/clang-tidy
 [build_requires]
 [env]
 CC=/usr/local/bin/clang

--- a/config/conan/profiles/clang-libstdcxx
+++ b/config/conan/profiles/clang-libstdcxx
@@ -8,10 +8,13 @@ compiler.version=10
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]
+enable_clang_tidy=On
+clang_tidy_path=/usr/local/bin/clang-tidy
 [build_requires]
 [env]
 CC=/usr/local/bin/clang
 CXX=/usr/local/bin/clang++
 CXXFLAGS=-std=c++2a -Xclang -fconcepts-ts -D_GLIBCXX_HAVE_BUILTIN_IS_CONSTANT_EVALUATED -fdiagnostics-color=always -Werror -Wall -Wextra -Wcast-align -Wconversion -Wdouble-promotion -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wpedantic -Wshadow -Wsign-conversion -Wsign-promo -Wunused -Wformat=2 -Wodr -Wno-attributes -Wnull-dereference
 LDFLAGS=-fuse-ld=lld
+LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/local/libexec
 CONAN_CMAKE_GENERATOR=Ninja

--- a/config/conan/profiles/clang-libstdcxx
+++ b/config/conan/profiles/clang-libstdcxx
@@ -8,8 +8,8 @@ compiler.version=10
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]
-enable_clang_tidy=On
-clang_tidy_path=/usr/local/bin/clang-tidy
+ranges:enable_clang_tidy=On
+ranges:clang_tidy_path=/usr/local/bin/clang-tidy
 [build_requires]
 [env]
 CC=/usr/local/bin/clang

--- a/config/conan/profiles/gcc
+++ b/config/conan/profiles/gcc
@@ -8,10 +8,11 @@ compiler.version=10
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]
+enable_clang_tidy=Off
 [build_requires]
 [env]
 CC=/usr/local/bin/gcc
 CXX=/usr/local/bin/g++
-CXXFLAGS=-std=c++2a -fdiagnostics-color=always -Werror -Wall -Wextra -Wcast-align -Wconversion -Wdouble-promotion -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wshadow -Wsign-conversion -Wsign-promo -Wunused -Wformat=2 -Wodr -Wno-attributes -Wnull-dereference
+CXXFLAGS=-std=c++2a -fdiagnostics-color=always -Werror -Wall -Wextra -Wcast-align -Wconversion -Wdouble-promotion -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wshadow -Wsign-conversion -Wsign-promo -Wunused -Wformat=2 -Wodr -Wno-attributes -Wnull-dereference -Wno-unused-local-typedefs -Wno-volatile
 LDFLAGS=-fuse-ld=gold
 CONAN_CMAKE_GENERATOR=Ninja

--- a/config/conan/profiles/gcc
+++ b/config/conan/profiles/gcc
@@ -8,7 +8,7 @@ compiler.version=10
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]
-enable_clang_tidy=Off
+ranges:enable_clang_tidy=Off
 [build_requires]
 [env]
 CC=/usr/local/bin/gcc


### PR DESCRIPTION
The existing infrastructure depends on building clang-concepts and GCC
(order dependent), which is slow and cumbersome. This commit changes the
behaviour so that clang-concepts and GCC can be built independently from
one another, and so that Cirrus will always build a Docker image based
on the latest built compilers.